### PR TITLE
Origin/Destinations/Maps/Driving Directions on Shifts

### DIFF
--- a/.gitIgnore
+++ b/.gitIgnore
@@ -7,3 +7,7 @@ src/profiles/Customer Community User.profile
 src/profiles/Partner Community Login User.profile
 src/profiles/Partner Community User.profile
 src/workflows/User.workflow
+*.sublime-*
+config/
+deploy/
+apex-scripts/

--- a/src/classes/VOL_CTRL_VolunteersJobListingFS.cls
+++ b/src/classes/VOL_CTRL_VolunteersJobListingFS.cls
@@ -200,9 +200,9 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
                 if (shiftIdFilter != null && nMonthsToShow == 0) {
                     listVolunteerJobs = [select Id, Name, Campaign__c, Campaign__r.IsActive, Campaign__r.Name, Campaign__r.StartDate, Campaign__r.Volunteer_Website_Time_Zone__c,
                         Description__c, Location_Information__c, Number_of_Shifts__c, Skills_Needed__c, Volunteer_Website_Time_Zone__c,
-                        Location_Street__c, Location_City__c, Location__c, Location_Zip_Postal_Code__c,
+                        Location_Street__c, Location_City__c, Location__c, Location_Zip_Postal_Code__c, 
                         (Select Id, Start_Date_Time__c, Duration__c, Number_of_Volunteers_Still_Needed__c,
-                            Description__c, System_Note__c From Volunteer_Job_Slots__r 
+                            Description__c, System_Note__c, Location_Street__c, Location_City__c, Location_State__c, Location_Zip_Postal_Code__c, Destination_Street__c, Destination_City__c, Destination_State__c, Destination_Zip_Postal_Code__c, Display_Map_on_Website__c From Volunteer_Job_Slots__r 
                             where Id = :shiftIdFilter) 
                         from Volunteer_Job__c where Id = :jobIdFilter  
                         order by First_Shift__c, Campaign__r.StartDate, Campaign__r.Name, Name];
@@ -211,7 +211,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
                         Description__c, Location_Information__c, Number_of_Shifts__c, Skills_Needed__c, Volunteer_Website_Time_Zone__c,
                         Location_Street__c, Location_City__c, Location__c, Location_Zip_Postal_Code__c,
                         (Select Id, Start_Date_Time__c, Duration__c, Number_of_Volunteers_Still_Needed__c,
-                            Description__c, System_Note__c From Volunteer_Job_Slots__r 
+                            Description__c, System_Note__c, Location_Street__c, Location_City__c, Location_State__c, Location_Zip_Postal_Code__c, Destination_Street__c, Destination_City__c, Destination_State__c, Destination_Zip_Postal_Code__c, Display_Map_on_Website__c From Volunteer_Job_Slots__r 
                             where Start_Date_Time__c >= :dtNow and Start_Date_Time__c < :dtLast
                             order by Start_Date_Time__c) 
                         from Volunteer_Job__c where Id = :jobIdFilter  
@@ -225,7 +225,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
                         Description__c, Location_Information__c, Number_of_Shifts__c, Skills_Needed__c, Volunteer_Website_Time_Zone__c,
                         Location_Street__c, Location_City__c, Location__c, Location_Zip_Postal_Code__c,
                         (Select Id, Start_Date_Time__c, Duration__c, Number_of_Volunteers_Still_Needed__c,
-                            Description__c, System_Note__c From Volunteer_Job_Slots__r 
+                            Description__c, System_Note__c, Location_Street__c, Location_City__c, Location_State__c, Location_Zip_Postal_Code__c, Destination_Street__c, Destination_City__c, Destination_State__c, Destination_Zip_Postal_Code__c, Display_Map_on_Website__c From Volunteer_Job_Slots__r 
                             where Start_Date_Time__c >= :dtNow and Start_Date_Time__c < :dtLast
                             order by Start_Date_Time__c) 
                         from Volunteer_Job__c where Campaign__c IN :listCampaignIds and Display_on_Website__c = true 
@@ -235,7 +235,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
                         Description__c, Location_Information__c, Number_of_Shifts__c, Skills_Needed__c, Volunteer_Website_Time_Zone__c,
                         Location_Street__c, Location_City__c, Location__c, Location_Zip_Postal_Code__c,
                         (Select Id, Start_Date_Time__c, Duration__c, Number_of_Volunteers_Still_Needed__c,
-                            Description__c, System_Note__c From Volunteer_Job_Slots__r 
+                            Description__c, System_Note__c, Location_Street__c, Location_City__c, Location_State__c, Location_Zip_Postal_Code__c, Destination_Street__c, Destination_City__c, Destination_State__c, Destination_Zip_Postal_Code__c, Display_Map_on_Website__c From Volunteer_Job_Slots__r 
                             where Start_Date_Time__c >= :dtNow and Start_Date_Time__c < :dtLast
                             order by Start_Date_Time__c LIMIT 100) 
                         from Volunteer_Job__c where Campaign__r.IsActive = true and Display_on_Website__c = true 

--- a/src/layouts/Volunteer_Shift__c-Volunteer Shift Layout.layout
+++ b/src/layouts/Volunteer_Shift__c-Volunteer Shift Layout.layout
@@ -45,6 +45,58 @@
     </layoutSections>
     <layoutSections>
         <customLabel>true</customLabel>
+        <detailHeading>true</detailHeading>
+        <editHeading>true</editHeading>
+        <label>Location(s)</label>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Location_Street__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Location_City__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Location_State__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Location_Zip_Postal_Code__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Destination_Street__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Destination_City__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Destination_State__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Destination_Zip_Postal_Code__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <style>TwoColumnsLeftToRight</style>
+    </layoutSections>
+    <layoutSections>
+        <customLabel>true</customLabel>
+        <detailHeading>true</detailHeading>
+        <editHeading>true</editHeading>
+        <label>Additional Information</label>
+        <layoutColumns/>
+        <layoutColumns/>
+        <style>TwoColumnsLeftToRight</style>
+    </layoutSections>
+    <layoutSections>
+        <customLabel>true</customLabel>
         <detailHeading>false</detailHeading>
         <editHeading>true</editHeading>
         <label>System Fields - DO NOT EDIT</label>
@@ -112,7 +164,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h50000001Sew9</masterLabel>
+        <masterLabel>00h1500000WMS1M</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/src/objects/Volunteer_Shift__c.object
+++ b/src/objects/Volunteer_Shift__c.object
@@ -46,7 +46,6 @@
     </actionOverrides>
     <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
-    <deprecated>false</deprecated>
     <enableActivities>true</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableFeeds>false</enableFeeds>
@@ -56,7 +55,6 @@
     <enableStreamingApi>true</enableStreamingApi>
     <fields>
         <fullName>Description__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Description</label>
         <length>32000</length>
@@ -66,7 +64,6 @@
     </fields>
     <fields>
         <fullName>Desired_Number_of_Volunteers__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Desired # of Volunteers</label>
         <precision>5</precision>
@@ -77,8 +74,47 @@
         <unique>false</unique>
     </fields>
     <fields>
+        <fullName>Destination_City__c</fullName>
+        <externalId>false</externalId>
+        <label>Destination City</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Destination_State__c</fullName>
+        <externalId>false</externalId>
+        <label>Destination State/Province</label>
+        <length>100</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Destination_Street__c</fullName>
+        <externalId>false</externalId>
+        <label>Destination Street</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Destination_Zip_Postal_Code__c</fullName>
+        <externalId>false</externalId>
+        <label>Destination Zip/Postal Code</label>
+        <length>100</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>Duration__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>How many hours long is the shift?</inlineHelpText>
         <label>Duration (Hours)</label>
@@ -91,7 +127,6 @@
     </fields>
     <fields>
         <fullName>Job_Location_City__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>Volunteer_Job__r.Location_City__c</formula>
         <label>Job Location City</label>
@@ -102,7 +137,6 @@
     </fields>
     <fields>
         <fullName>Job_Location_State_Province__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>Volunteer_Job__r.Location__c</formula>
         <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
@@ -114,7 +148,6 @@
     </fields>
     <fields>
         <fullName>Job_Location_Street__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>Volunteer_Job__r.Location_Street__c</formula>
         <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
@@ -126,7 +159,6 @@
     </fields>
     <fields>
         <fullName>Job_Location_Zip_Postal_Code__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>Volunteer_Job__r.Location_Zip_Postal_Code__c</formula>
         <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
@@ -139,7 +171,6 @@
     <fields>
         <fullName>Job_Recurrence_Schedule__c</fullName>
         <deleteConstraint>SetNull</deleteConstraint>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Automatically set by the system scheduler to show the Job Recurrence Schedule this shift is associated with.</inlineHelpText>
         <label>Job Recurrence Schedule</label>
@@ -151,8 +182,47 @@
         <type>Lookup</type>
     </fields>
     <fields>
+        <fullName>Location_City__c</fullName>
+        <externalId>false</externalId>
+        <label>Location City</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Location_State__c</fullName>
+        <externalId>false</externalId>
+        <label>Location State/Province</label>
+        <length>100</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Location_Street__c</fullName>
+        <externalId>false</externalId>
+        <label>Location Street</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Location_Zip_Postal_Code__c</fullName>
+        <externalId>false</externalId>
+        <label>Location Zip/Postal Code</label>
+        <length>100</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>Number_of_Volunteers_Still_Needed__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>max ( 0, Desired_Number_of_Volunteers__c -  BLANKVALUE(Total_Volunteers__c, 0))</formula>
         <label># of Volunteers Still Needed</label>
@@ -165,7 +235,6 @@
     </fields>
     <fields>
         <fullName>Start_Date_Time__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Start Date &amp; Time</label>
         <required>true</required>
@@ -174,7 +243,6 @@
     </fields>
     <fields>
         <fullName>System_Note__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Text information from the system scheduler.</inlineHelpText>
         <label>System Note</label>
@@ -186,7 +254,6 @@
     </fields>
     <fields>
         <fullName>Total_Volunteers__c</fullName>
-        <deprecated>false</deprecated>
         <description>This field is maintained by the VOL_VolunteerHours_ShiftRollups trigger.</description>
         <externalId>false</externalId>
         <inlineHelpText>SYSTEM FIELD.  DO NOT EDIT.  The total number of volunteers whose Hours Status = Completed or Confirmed.</inlineHelpText>
@@ -200,7 +267,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Job__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteer Job</label>
         <referenceTo>Volunteer_Job__c</referenceTo>

--- a/src/package.xml
+++ b/src/package.xml
@@ -3,7 +3,6 @@
     <fullName>Volunteers for Salesforce</fullName>
     <apiAccessLevel>Unrestricted</apiAccessLevel>
     <description>Volunteers for Salesforce managed package, by David Habib of DJH Consulting.</description>
-    <namespacePrefix>GW_Volunteers</namespacePrefix>
     <types>
         <members>ComponentControllerBase</members>
         <members>GW_CTRL_BatchJobsProgress</members>

--- a/src/pages/VolunteersJobListingFS.page
+++ b/src/pages/VolunteersJobListingFS.page
@@ -109,14 +109,13 @@
             <apex:outputField value="{!job.Location_City__c}" />,&nbsp;
             <apex:outputField value="{!job.Location__c}" />&nbsp;&nbsp;
             <apex:outputField value="{!job.Location_Zip_Postal_Code__c}" />
-			<apex:outputPanel rendered="{!ShowLocationMap && strGoogleMapAPIKey <> null}">
-				<p class="cssJobLocationMap">
-				<iframe class="cssGoogleMapIFrame" 
-					src="https://www.google.com/maps/embed/v1/place?q={!job.Location_Street__c}+{!job.Location_City__c}+{!job.Location__c}+{!job.Location_Zip_Postal_Code__c}&key={!strGoogleMapAPIKey}">
-				</iframe>
-                YAY MAP
-				</p>
-			</apex:outputPanel>            
+			</p>
+        </apex:outputPanel>
+        <apex:outputPanel rendered="{!ShowLocationMap && job.Location_Street__c <> null && strGoogleMapAPIKey <> null}">
+            <p class="cssJobLocationMap">
+            <iframe class="cssGoogleMapIFrame" 
+                src="https://www.google.com/maps/embed/v1/place?q={!job.Location_Street__c}+{!job.Location_City__c}+{!job.Location__c}+{!job.Location_Zip_Postal_Code__c}&key={!strGoogleMapAPIKey}">
+            </iframe>
             </p>
         </apex:outputPanel>
         <apex:outputPanel rendered="{!ShowLocationInfo && job.Location_Information__c <> null}">
@@ -126,10 +125,9 @@
         </apex:outputPanel>
         <apex:outputPanel id="panelJobOnly" rendered="{!job.Number_of_Shifts__c == 0 || ShowShifts == false}" >
             <input type="button" value="{!$Label.labelButtonSignUp}"  class="cssJobShiftSignup btn" onclick="OpenSignUpDlg(event.clientX, event.clientY, '{!job.Id}', '', '{!JSENCODE(job.Name)}', ''); return false;"/>
-        </apex:outputPanel>         
-        <apex:dataTable value="{!job.Volunteer_Job_Slots__r}" var="shift" id="rptShifts" columnClasses="cssJobShiftSignup" rendered="{!ShowShifts}" >
-            <apex:column style="text-align:center;" >
-                <apex:outputPanel rendered="{!shift.Number_of_Volunteers_Still_Needed__c != 0}" >
+        </apex:outputPanel>
+        <apex:repeat value="{!job.Volunteer_Job_Slots__r}" var="shift" id="rptShiftsDivs" rendered="{!ShowShifts}">
+               <apex:outputPanel rendered="{!shift.Number_of_Volunteers_Still_Needed__c != 0}" layout="inline">
                     <a href="SignUp" onclick="
                     	var x = '{!shift.System_Note__c}';   
                     	if (x == '') x = JobShiftDateTimeString('{!shift.Start_Date_Time__c}', '{!shift.Duration__c}');
@@ -137,20 +135,64 @@
                         return false;"
                         >{!$Label.labelLinkSignUp}</a>
                 </apex:outputPanel>
-                <apex:outputText value="{!$Label.labelLinkFull}" style="font-style:italic;" rendered="{!BLANKVALUE(shift.Number_of_Volunteers_Still_Needed__c, -1) == 0}" />
-                &nbsp;&nbsp;&nbsp;
-            </apex:column>
-            <apex:column >
-            	<div id="txtShiftStartDateTime">
+                <apex:outputText value="{!$Label.labelLinkFull}" id="txtShiftStartDateTime" style="font-style:italic;" rendered="{!BLANKVALUE(shift.Number_of_Volunteers_Still_Needed__c, -1) == 0}" />
             		<script>
 		            	var strDT = '{!shift.System_Note__c}';
 		            	if (strDT == '') strDT = JobShiftDateTimeString('{!shift.Start_Date_Time__c}', '{!shift.Duration__c}'); 
 		            	document.write(strDT);
 		            </script>&nbsp;&nbsp;&nbsp;
-		        </div>
-		    </apex:column>
-            <apex:column ><apex:outputField value="{!shift.Description__c}" /></apex:column>
-        </apex:dataTable>
+				<apex:outputField value="{!shift.Description__c}" />
+            	<div id="shiftMap">
+                    <apex:outputPanel rendered="{!
+                        (
+                            (
+                            shift.Display_Map_on_Website__c == 'Location/Origin Only' 
+                            && NOT(ISBLANK(shift.Location_Street__c))
+                            )
+                            ||
+                            (
+                            shift.Display_Map_on_Website__c == 'Driving Directions' 
+                            && NOT(ISBLANK(shift.Location_Street__c)) 
+                            && ISBLANK(shift.Destination_Street__c)
+                            )
+                        ) 
+                        && NOT(ISBLANK(strGoogleMapAPIKey))
+                    }">
+                        <p class="cssJobLocationMap">
+                        <iframe class="cssGoogleMapIFrame" 
+                            src="https://www.google.com/maps/embed/v1/place?q={!shift.Location_Street__c}+{!shift.Location_City__c}+{!shift.Location_State__c}+{!shift.Location_Zip_Postal_Code__c}&key={!strGoogleMapAPIKey}">
+                        </iframe>
+                        </p>
+                    </apex:outputPanel>
+                    <apex:outputPanel rendered="{!
+                    (
+                        (
+                            shift.Display_Map_on_Website__c == 'Destination Only' 
+                            && NOT(ISBLANK(shift.Destination_Street__c))
+                        )
+                        ||
+                        (
+                            shift.Display_Map_on_Website__c == 'Driving Directions' 
+                            && ISBLANK(shift.Location_Street__c) 
+                            && NOT(ISBLANK(shift.Destination_Street__c))
+                        )
+                    ) 
+                    && NOT(ISBLANK(strGoogleMapAPIKey))}">
+                        <p class="cssJobLocationMap">
+                        <iframe class="cssGoogleMapIFrame" 
+                            src="https://www.google.com/maps/embed/v1/place?q={!shift.Destination_Street__c}+{!shift.Destination_City__c}+{!shift.Destination_State__c}+{!shift.Destination_Zip_Postal_Code__c}&key={!strGoogleMapAPIKey}">
+                        </iframe>
+                        </p>
+                    </apex:outputPanel>
+                    <apex:outputPanel rendered="{!shift.Display_Map_on_Website__c == 'Driving Directions' && NOT(ISBLANK(shift.Location_Street__c)) && NOT(ISBLANK(shift.Destination_Street__c)) && NOT(ISBLANK(strGoogleMapAPIKey))}">
+                        <p class="cssJobLocationMap">
+                        <iframe class="cssGoogleMapIFrame" 
+                            src="https://www.google.com/maps/embed/v1/directions?origin={!shift.Location_Street__c}+{!shift.Location_City__c}+{!shift.Location_State__c}+{!shift.Location_Zip_Postal_Code__c}&destination={!shift.Destination_Street__c}+{!shift.Destination_City__c}+{!shift.Destination_State__c}+{!shift.Destination_Zip_Postal_Code__c}&key={!strGoogleMapAPIKey}">
+                        </iframe>
+                        </p>
+                    </apex:outputPanel>
+                </div>
+        </apex:repeat>
         <br/>
         <br/> 
         <apex:outputPanel rendered="{!NOT(fCalendar)}" ><hr/></apex:outputPanel>

--- a/src/pages/VolunteersJobListingFS.page
+++ b/src/pages/VolunteersJobListingFS.page
@@ -114,6 +114,7 @@
 				<iframe class="cssGoogleMapIFrame" 
 					src="https://www.google.com/maps/embed/v1/place?q={!job.Location_Street__c}+{!job.Location_City__c}+{!job.Location__c}+{!job.Location_Zip_Postal_Code__c}&key={!strGoogleMapAPIKey}">
 				</iframe>
+                YAY MAP
 				</p>
 			</apex:outputPanel>            
             </p>

--- a/src/pages/VolunteersJobListingFS.page
+++ b/src/pages/VolunteersJobListingFS.page
@@ -103,22 +103,22 @@
             <apex:outputField value="{!job.Skills_Needed__c}" />
             </p>  
         </apex:outputPanel>
-        <apex:outputPanel rendered="{!ShowLocationAddress && job.Location_Street__c <> null}" >
+         <apex:outputPanel rendered="{!ShowLocationAddress && job.Location_Street__c <> null}" >
             <p class="cssJobLocationAddress">
             <apex:outputField value="{!job.Location_Street__c}" /><br/>
             <apex:outputField value="{!job.Location_City__c}" />,&nbsp;
             <apex:outputField value="{!job.Location__c}" />&nbsp;&nbsp;
             <apex:outputField value="{!job.Location_Zip_Postal_Code__c}" />
-			</p>
-        </apex:outputPanel>
-        <apex:outputPanel rendered="{!ShowLocationMap && job.Location_Street__c <> null && strGoogleMapAPIKey <> null}">
-            <p class="cssJobLocationMap">
-            <iframe class="cssGoogleMapIFrame" 
-                src="https://www.google.com/maps/embed/v1/place?q={!job.Location_Street__c}+{!job.Location_City__c}+{!job.Location__c}+{!job.Location_Zip_Postal_Code__c}&key={!strGoogleMapAPIKey}">
-            </iframe>
+            <apex:outputPanel rendered="{!ShowLocationMap && strGoogleMapAPIKey <> null}">
+                <p class="cssJobLocationMap">
+                <iframe class="cssGoogleMapIFrame" 
+                    src="https://www.google.com/maps/embed/v1/place?q={!job.Location_Street__c}+{!job.Location_City__c}+{!job.Location__c}+{!job.Location_Zip_Postal_Code__c}&key={!strGoogleMapAPIKey}">
+                </iframe>
+                </p>
+            </apex:outputPanel>            
             </p>
         </apex:outputPanel>
-        <apex:outputPanel rendered="{!ShowLocationInfo && job.Location_Information__c <> null}">
+       <apex:outputPanel rendered="{!ShowLocationInfo && job.Location_Information__c <> null}">
             <p>
             <apex:outputField value="{!job.Location_Information__c}" />
             </p>


### PR DESCRIPTION
Closes #170. 
Added Location/Origin and Destination Address blocks on Volunteer Shift object, along with a picklist to select how the Shift map should appear on VolunteerJobListingFS. Used a picklist so admins can set preferred behaviour as default value.
