### PR TITLE
Feature/lex btn fixes

### DIFF
--- a/src/classes/VOL_CTRL_SendBulkEmail.cls
+++ b/src/classes/VOL_CTRL_SendBulkEmail.cls
@@ -47,11 +47,26 @@ public with sharing class VOL_CTRL_SendBulkEmail {
 	
 	// constructor
 	public VOL_CTRL_SendBulkEmail() { 
+
+		// backward compatibility. when not called from a StandardController,
+		// assume object id passed in appropriate URL parameter
+        Map<String, String> mapParams = ApexPages.currentPage().getParameters();
+		campaignId = mapParams.get('campaignId');
+		jobId = mapParams.get('jobId');
+		shiftId = mapParams.get('shiftId');
+
+        if (campaignId == null && jobId == null && shiftId == null) {		
+			// When called from StandardController, figure out what object type it is.
+			ID id = mapParams.get('id');
+			if (VOL_SharedCode.isObjectIdThisType(id, 'Campaign')) {
+			    campaignId = id;
+			} else if (VOL_SharedCode.isObjectIdThisType(id, VOL_SharedCode.StrTokenNSPrefix('Volunteer_Job__c'))) {
+                jobId = id;
+			} else if (VOL_SharedCode.isObjectIdThisType(id, VOL_SharedCode.StrTokenNSPrefix('Volunteer_Shift__c'))) {
+                shiftId = id;
+            }
+		}
 		
-		// figure out what object we were invoked from
-		campaignId = ApexPages.currentPage().getParameters().get('campaignId');
-		jobId = ApexPages.currentPage().getParameters().get('jobId');
-		shiftId = ApexPages.currentPage().getParameters().get('shiftId');
 		fEmailContactsOnlyOnce = false;
 		
 		if (shiftId != null) {
@@ -282,10 +297,19 @@ public with sharing class VOL_CTRL_SendBulkEmail {
     // action method that user wants to close this page
     public PageReference Cancel() {
         string strURL = ApexPages.currentPage().getParameters().get('retURL');
-        if (strURL == null || strURL == '') strURL = '\\';
+        if (strURL == null || strURL == '') {
+            strURL = '/' + strCleanNull(campaignId) + strCleanNull(jobId) + strCleanNull(shiftId);
+        }
         PageReference p = new PageReference(strURL);
         p.setRedirect(true);
         return p;
     }
     
+    // string helper for dealing with nulls
+    private static string strCleanNull(string str) {
+        if (str == null)
+            return '';
+       	else
+            return str;
+    }
 }

--- a/src/classes/VOL_CTRL_VolunteersFind.cls
+++ b/src/classes/VOL_CTRL_VolunteersFind.cls
@@ -44,15 +44,34 @@ public with sharing class VOL_CTRL_VolunteersFind extends PageControllerBase {
         listSOCampaigns = volSharedCode.listSOCampaignsWithJobs;  
         
         // handle optional parameters (must use string, not ID, to handle null)
-        string id = ApexPages.currentPage().getParameters().get('campaignId');
+        // backward compatibility. when not called from a StandardController,
+        // assume object id passed in appropriate URL parameter
+        Map<String, String> mapParams = ApexPages.currentPage().getParameters();
+        string id = mapParams.get('campaignId');
         if (id != null && id != '') campaignId = id;
         
-        id = ApexPages.currentPage().getParameters().get('volunteerJobId');
+        id = mapParams.get('volunteerJobId');
         if (id != null && id != '') volunteerJobId = id;
 
-        id = ApexPages.currentPage().getParameters().get('volunteerShiftId');
+        id = mapParams.get('volunteerShiftId');
         if (id != null && id != '') volunteerShiftId = id;
-            			
+        
+        if (campaignId == null && volunteerJobId == null && volunteerShiftId == null) {       
+            // When called from StandardController, figure out what object type it is.
+            id = mapParams.get('id');
+            if (VOL_SharedCode.isObjectIdThisType(id, 'Campaign')) {
+                campaignId = id;
+            } else if (VOL_SharedCode.isObjectIdThisType(id, VOL_SharedCode.StrTokenNSPrefix('Volunteer_Job__c'))) {
+                Volunteer_Job__c job = [select Campaign__c from Volunteer_Job__c where Id = :id];
+                campaignId = job.Campaign__c;
+                volunteerJobId = id;
+            } else if (VOL_SharedCode.isObjectIdThisType(id, VOL_SharedCode.StrTokenNSPrefix('Volunteer_Shift__c'))) {
+                Volunteer_Shift__c shift = [select Volunteer_Job__c, Volunteer_Job__r.Campaign__c from Volunteer_Shift__c where Id = :id];
+                campaignId = shift.Volunteer_Job__r.Campaign__c;
+                volunteerJobId = shift.Volunteer_Job__c;
+                volunteerShiftId = id;
+            }
+        }
 	}
 	
 	// the SoqlListView component calls this method to get the query string.

--- a/src/classes/VOL_SharedCode.cls
+++ b/src/classes/VOL_SharedCode.cls
@@ -788,5 +788,54 @@ global with sharing class VOL_SharedCode {
         return new List<Id>(campaignsInHierarchy.keySet());
     }
 
+    // throw custom exceptions when a bogus object or field is provided.
+    public class SchemaDescribeException extends Exception {}
+
+    //maps to cache the describe info
+    private static Map<String, Schema.SObjectType> gd;
+    private static Map<String, Schema.DescribeSObjectResult> objectDescribes = new Map<String, Schema.DescribeSObjectResult>();
+
+    /*******************************************************************************************************
+    * @description fills describe map for a new object
+    * @param objectName
+    * @return void
+    */
+    private static void fillMapsForObject(string objectName) {
+        // get the object map the first time
+        if (gd == null) {
+            gd = Schema.getGlobalDescribe();
+        }
+
+        // get the object description
+        if (gd.containsKey(objectName)) {
+
+            if (!objectDescribes.containsKey(objectName))
+                objectDescribes.put(objectName, gd.get(objectName).getDescribe());
+        } else {
+            throw new SchemaDescribeException('Invalid object name \'' + objectName + '\'');
+        }
+    }
+
+    /*******************************************************************************************************
+    * @description Compares Id to verify object type
+    * @param salesforceId of the object
+    * @param objectName
+    * @return true if the Id is for the given object type, false otherwise.
+    */
+    public static boolean isObjectIdThisType(Id salesforceId, String objectName) {
+
+        // make sure we have this object's schema mapped
+        if (!objectDescribes.containsKey(objectName))
+            fillMapsForObject(objectName);
+
+        // now grab the requested id prefix
+        boolean ret = false;
+        if (salesforceId != null) {
+            string prefix = objectDescribes.get(objectName).getKeyPrefix();
+            if (prefix != null)
+                ret = ((string)(salesforceId)).startsWith(prefix);
+        }
+        return ret;
+    }
      
 }

--- a/src/objects/Campaign.object
+++ b/src/objects/Campaign.object
@@ -72,7 +72,6 @@
     </fieldSets>
     <fields>
         <fullName>Number_of_Volunteers__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>The total number of volunteers whose Hours Status = Completed or Confirmed.</inlineHelpText>
         <label>Number of Volunteers</label>
@@ -83,7 +82,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Completed_Hours__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Total number of hours that are completed.  Hours with other status values are not included.</inlineHelpText>
         <label>Volunteer Completed Hours</label>
@@ -94,7 +92,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Jobs__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteer Jobs</label>
         <summaryForeignKey>Volunteer_Job__c.Campaign__c</summaryForeignKey>
@@ -103,7 +100,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Shifts__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteer Shifts</label>
         <summarizedField>Volunteer_Job__c.Number_of_Shifts__c</summarizedField>
@@ -113,7 +109,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Website_Time_Zone__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>The Time Zone to use when displaying Shift times on Sites pages.  You only need to set this if you want to override the Time Zone set on the Site Guest User profile.</inlineHelpText>
         <label>Volunteer Website Time Zone</label>
@@ -477,7 +472,6 @@
     </fields>
     <fields>
         <fullName>Volunteers_Still_Needed__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteers Still Needed</label>
         <summarizedField>Volunteer_Job__c.Number_of_Volunteers_Still_Needed__c</summarizedField>
@@ -961,13 +955,12 @@
         <fullName>Find_Volunteers</fullName>
         <availability>online</availability>
         <displayType>button</displayType>
-        <encodingKey>UTF-8</encodingKey>
         <height>600</height>
-        <linkType>url</linkType>
+        <linkType>page</linkType>
         <masterLabel>Find Volunteers</masterLabel>
         <openType>sidebar</openType>
+        <page>VolunteersFind_Campaign</page>
         <protected>false</protected>
-        <url>/apex/GW_Volunteers__VolunteersFind?campaignId={!Campaign.Id}</url>
     </webLinks>
     <webLinks>
         <fullName>Mass_Email_Volunteers</fullName>

--- a/src/objects/Campaign.object
+++ b/src/objects/Campaign.object
@@ -973,14 +973,12 @@
         <fullName>Mass_Email_Volunteers</fullName>
         <availability>online</availability>
         <displayType>button</displayType>
-        <encodingKey>UTF-8</encodingKey>
         <height>600</height>
-        <linkType>url</linkType>
+        <linkType>page</linkType>
         <masterLabel>Mass Email Volunteers</masterLabel>
         <openType>sidebar</openType>
+        <page>SendBulkEmail_Campaign</page>
         <protected>false</protected>
-        <url>/apex/GW_Volunteers__SendBulkEmail?campaignId={!Campaign.Id}&amp;retURL={! 
-URLFOR( $Action.Campaign.View ,  Campaign.Id ) }</url>
     </webLinks>
     <webLinks>
         <fullName>New_Volunteer_Campaign</fullName>

--- a/src/objects/Volunteer_Job__c.object
+++ b/src/objects/Volunteer_Job__c.object
@@ -21,6 +21,10 @@
         <type>Default</type>
     </actionOverrides>
     <actionOverrides>
+        <actionName>Follow</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
         <actionName>List</actionName>
         <type>Default</type>
     </actionOverrides>
@@ -43,7 +47,6 @@
     <allowInChatterGroups>false</allowInChatterGroups>
     <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
-    <deprecated>false</deprecated>
     <enableActivities>true</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableFeeds>false</enableFeeds>
@@ -54,7 +57,6 @@
     <enableStreamingApi>true</enableStreamingApi>
     <fields>
         <fullName>Campaign__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Campaign</label>
         <referenceTo>Campaign</referenceTo>
@@ -68,7 +70,6 @@
     </fields>
     <fields>
         <fullName>Description__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Description</label>
         <length>32000</length>
@@ -79,7 +80,6 @@
     <fields>
         <fullName>Display_on_Website__c</fullName>
         <defaultValue>false</defaultValue>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Check this field if this Volunteer Job should be included in the Available Volunteer Jobs Sites page.</inlineHelpText>
         <label>Display on Website</label>
@@ -88,7 +88,6 @@
     </fields>
     <fields>
         <fullName>External_Signup_Url__c</fullName>
-        <deprecated>false</deprecated>
         <description>If provided, the VolunteersJobListingFS page will redirect to this website when the user clicks on the Sign Up link on the page.  This allows you to advertise jobs that one must register for on another web site.</description>
         <externalId>false</externalId>
         <inlineHelpText>If provided, the VolunteersJobListingFS page will redirect to this website when the user clicks on the Sign Up link on the page.  This allows you to advertise jobs that one must register for on another web site.</inlineHelpText>
@@ -101,7 +100,6 @@
     </fields>
     <fields>
         <fullName>First_Shift__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>First Shift</label>
         <summarizedField>Volunteer_Shift__c.Start_Date_Time__c</summarizedField>
@@ -113,7 +111,6 @@
     <fields>
         <fullName>Inactive__c</fullName>
         <defaultValue>false</defaultValue>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Check if this Volunteer Job is no longer active, and it won&apos;t be included in the Volunteers Report Hours Sites page.</inlineHelpText>
         <label>Inactive</label>
@@ -122,7 +119,6 @@
     </fields>
     <fields>
         <fullName>Location_City__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Location City</label>
         <length>255</length>
@@ -133,7 +129,6 @@
     </fields>
     <fields>
         <fullName>Location_Information__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Put in any additional details, like driving directions or a URL to a map, in this field, and it will be included in automated email reminders.</inlineHelpText>
         <label>Location Information</label>
@@ -144,7 +139,6 @@
     </fields>
     <fields>
         <fullName>Location_Street__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Location Street</label>
         <length>255</length>
@@ -155,7 +149,6 @@
     </fields>
     <fields>
         <fullName>Location_Zip_Postal_Code__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Location Zip/Postal Code</label>
         <length>100</length>
@@ -166,7 +159,6 @@
     </fields>
     <fields>
         <fullName>Location__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Location State/Province</label>
         <length>100</length>
@@ -177,7 +169,6 @@
     </fields>
     <fields>
         <fullName>Number_of_Completed_Hours__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Total number of Hours that are Completed.  Hours with other status values are not included.</inlineHelpText>
         <label>Number of Completed Hours</label>
@@ -194,7 +185,6 @@
     </fields>
     <fields>
         <fullName>Number_of_Shifts__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Number of Shifts</label>
         <summaryForeignKey>Volunteer_Shift__c.Volunteer_Job__c</summaryForeignKey>
@@ -204,7 +194,6 @@
     </fields>
     <fields>
         <fullName>Number_of_Volunteers_Still_Needed__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label># of Volunteers Still Needed</label>
         <summarizedField>Volunteer_Shift__c.Number_of_Volunteers_Still_Needed__c</summarizedField>
@@ -215,7 +204,6 @@
     </fields>
     <fields>
         <fullName>Number_of_Volunteers__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>The total number of volunteers whose Hours Status = Completed or Confirmed.</inlineHelpText>
         <label>Number of Volunteers</label>
@@ -233,7 +221,6 @@
     <fields>
         <fullName>Ongoing__c</fullName>
         <defaultValue>false</defaultValue>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Ongoing</label>
         <trackTrending>false</trackTrending>
@@ -241,7 +228,6 @@
     </fields>
     <fields>
         <fullName>Skills_Needed__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>the skills the volunteer should have to do this job</inlineHelpText>
         <label>Skills Needed</label>
@@ -283,7 +269,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Website_Time_Zone__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>The Time Zone to use when displaying Shift times on Sites pages.   You only need to set this if you want to override both the Time Zone set on the Site Guest User profile, and the Time Zone set on the Volunteers campaign.</inlineHelpText>
         <label>Volunteer Website Time Zone</label>
@@ -723,13 +708,12 @@
         <fullName>Find_Volunteers</fullName>
         <availability>online</availability>
         <displayType>button</displayType>
-        <encodingKey>UTF-8</encodingKey>
         <height>600</height>
-        <linkType>url</linkType>
+        <linkType>page</linkType>
         <masterLabel>Find Volunteers</masterLabel>
         <openType>sidebar</openType>
+        <page>VolunteersFind_Job</page>
         <protected>false</protected>
-        <url>/apex/GW_Volunteers__VolunteersFind?campaignId={!Volunteer_Job__c.CampaignId__c}&amp;volunteerJobId={!Volunteer_Job__c.Id}</url>
     </webLinks>
     <webLinks>
         <fullName>JobRoster</fullName>

--- a/src/objects/Volunteer_Job__c.object
+++ b/src/objects/Volunteer_Job__c.object
@@ -769,13 +769,11 @@
         <fullName>Mass_Email_Volunteers</fullName>
         <availability>online</availability>
         <displayType>button</displayType>
-        <encodingKey>UTF-8</encodingKey>
         <height>600</height>
-        <linkType>url</linkType>
+        <linkType>page</linkType>
         <masterLabel>Mass Email Volunteers</masterLabel>
         <openType>sidebar</openType>
+        <page>SendBulkEmail_Job</page>
         <protected>false</protected>
-        <url>/apex/GW_Volunteers__SendBulkEmail?jobId={!Volunteer_Job__c.Id}&amp;retURL={! 
-URLFOR( $Action.Volunteer_Job__c.View , Volunteer_Job__c.Id ) }</url>
     </webLinks>
 </CustomObject>

--- a/src/objects/Volunteer_Shift__c.object
+++ b/src/objects/Volunteer_Shift__c.object
@@ -247,14 +247,12 @@
         <fullName>Mass_Email_Volunteers</fullName>
         <availability>online</availability>
         <displayType>button</displayType>
-        <encodingKey>UTF-8</encodingKey>
         <height>600</height>
-        <linkType>url</linkType>
+        <linkType>page</linkType>
         <masterLabel>Mass Email Volunteers</masterLabel>
         <openType>sidebar</openType>
+        <page>SendBulkEmail_Shift</page>
         <protected>false</protected>
-        <url>/apex/GW_Volunteers__SendBulkEmail?jobId={!Volunteer_Job__c.Id}&amp;shiftId={!Volunteer_Shift__c.Id}&amp;retURL={! 
-URLFOR( $Action.Volunteer_Shift__c.View , Volunteer_Shift__c.Id ) }</url>
     </webLinks>
     <webLinks>
         <fullName>Roster</fullName>

--- a/src/objects/Volunteer_Shift__c.object
+++ b/src/objects/Volunteer_Shift__c.object
@@ -21,6 +21,10 @@
         <type>Default</type>
     </actionOverrides>
     <actionOverrides>
+        <actionName>Follow</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
         <actionName>List</actionName>
         <type>Default</type>
     </actionOverrides>
@@ -43,7 +47,6 @@
     <allowInChatterGroups>false</allowInChatterGroups>
     <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
-    <deprecated>false</deprecated>
     <enableActivities>true</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableFeeds>false</enableFeeds>
@@ -54,7 +57,6 @@
     <enableStreamingApi>true</enableStreamingApi>
     <fields>
         <fullName>Description__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Description</label>
         <length>32000</length>
@@ -64,7 +66,6 @@
     </fields>
     <fields>
         <fullName>Desired_Number_of_Volunteers__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Desired # of Volunteers</label>
         <precision>5</precision>
@@ -76,7 +77,6 @@
     </fields>
     <fields>
         <fullName>Duration__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>How many hours long is the shift?</inlineHelpText>
         <label>Duration (Hours)</label>
@@ -89,7 +89,6 @@
     </fields>
     <fields>
         <fullName>Job_Location_City__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>Volunteer_Job__r.Location_City__c</formula>
         <label>Job Location City</label>
@@ -100,7 +99,6 @@
     </fields>
     <fields>
         <fullName>Job_Location_State_Province__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>Volunteer_Job__r.Location__c</formula>
         <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
@@ -112,7 +110,6 @@
     </fields>
     <fields>
         <fullName>Job_Location_Street__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>Volunteer_Job__r.Location_Street__c</formula>
         <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
@@ -124,7 +121,6 @@
     </fields>
     <fields>
         <fullName>Job_Location_Zip_Postal_Code__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>Volunteer_Job__r.Location_Zip_Postal_Code__c</formula>
         <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
@@ -137,7 +133,6 @@
     <fields>
         <fullName>Job_Recurrence_Schedule__c</fullName>
         <deleteConstraint>SetNull</deleteConstraint>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Automatically set by the system scheduler to show the Job Recurrence Schedule this shift is associated with.</inlineHelpText>
         <label>Job Recurrence Schedule</label>
@@ -150,7 +145,6 @@
     </fields>
     <fields>
         <fullName>Number_of_Volunteers_Still_Needed__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>max ( 0, Desired_Number_of_Volunteers__c -  BLANKVALUE(Total_Volunteers__c, 0))</formula>
         <label># of Volunteers Still Needed</label>
@@ -163,7 +157,6 @@
     </fields>
     <fields>
         <fullName>Start_Date_Time__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Start Date &amp; Time</label>
         <required>true</required>
@@ -172,7 +165,6 @@
     </fields>
     <fields>
         <fullName>System_Note__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Text information from the system scheduler.</inlineHelpText>
         <label>System Note</label>
@@ -184,7 +176,6 @@
     </fields>
     <fields>
         <fullName>Total_Volunteers__c</fullName>
-        <deprecated>false</deprecated>
         <description>This field is maintained by the VOL_VolunteerHours_ShiftRollups trigger.</description>
         <externalId>false</externalId>
         <inlineHelpText>SYSTEM FIELD.  DO NOT EDIT.  The total number of volunteers whose Hours Status = Completed or Confirmed.</inlineHelpText>
@@ -198,7 +189,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Job__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteer Job</label>
         <referenceTo>Volunteer_Job__c</referenceTo>
@@ -235,13 +225,12 @@
         <fullName>Find_Volunteers</fullName>
         <availability>online</availability>
         <displayType>button</displayType>
-        <encodingKey>UTF-8</encodingKey>
         <height>600</height>
-        <linkType>url</linkType>
+        <linkType>page</linkType>
         <masterLabel>Find Volunteers</masterLabel>
         <openType>sidebar</openType>
+        <page>VolunteersFind_Shift</page>
         <protected>false</protected>
-        <url>/apex/GW_Volunteers__VolunteersFind?campaignId={!Volunteer_Job__c.CampaignId__c}&amp;volunteerJobId={!Volunteer_Shift__c.Volunteer_JobId__c}&amp;volunteerShiftId={!Volunteer_Shift__c.Id}</url>
     </webLinks>
     <webLinks>
         <fullName>Mass_Email_Volunteers</fullName>

--- a/src/package.xml
+++ b/src/package.xml
@@ -80,6 +80,9 @@
         <members>VolunteersBulkEnterHours</members>
         <members>VolunteersCampaignWizard</members>
         <members>VolunteersFind</members>
+        <members>VolunteersFind_Campaign</members>
+        <members>VolunteersFind_Job</members>
+        <members>VolunteersFind_Shift</members>
         <members>VolunteersJobListing</members>
         <members>VolunteersJobListingFS</members>
         <members>VolunteersReportHours</members>

--- a/src/package.xml
+++ b/src/package.xml
@@ -72,6 +72,9 @@
         <members>PersonalSiteTemplate</members>
         <members>PersonalSiteTemplateEspanol</members>
         <members>SendBulkEmail</members>
+        <members>SendBulkEmail_Campaign</members>
+        <members>SendBulkEmail_Job</members>
+        <members>SendBulkEmail_Shift</members>
         <members>VolunteersAbout</members>
         <members>VolunteersBatchJobsProgress</members>
         <members>VolunteersBulkEnterHours</members>

--- a/src/pages/SendBulkEmail_Campaign.page
+++ b/src/pages/SendBulkEmail_Campaign.page
@@ -1,0 +1,32 @@
+<!-- 
+    Copyright (c) 2016, salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    3. Neither the name of Salesforce.org nor the names of
+       its contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+-->
+<apex:page standardController="Campaign" title="{!$Label.labelMassEmailVolunteersTitle}" tabStyle="Task" >
+    <apex:include pageName="SendBulkEmail"/>
+</apex:page>

--- a/src/pages/SendBulkEmail_Campaign.page-meta.xml
+++ b/src/pages/SendBulkEmail_Campaign.page-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>37.0</apiVersion>
+    <availableInTouch>false</availableInTouch>
+    <confirmationTokenRequired>false</confirmationTokenRequired>
+    <label>SendBulkEmail_Campaign</label>
+</ApexPage>

--- a/src/pages/SendBulkEmail_Campaign.page-meta.xml
+++ b/src/pages/SendBulkEmail_Campaign.page-meta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>37.0</apiVersion>
-    <availableInTouch>false</availableInTouch>
+    <apiVersion>31.0</apiVersion>
+    <availableInTouch>true</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>SendBulkEmail_Campaign</label>
 </ApexPage>

--- a/src/pages/SendBulkEmail_Job.page
+++ b/src/pages/SendBulkEmail_Job.page
@@ -1,0 +1,32 @@
+<!-- 
+    Copyright (c) 2016, salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    3. Neither the name of Salesforce.org nor the names of
+       its contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+-->
+<apex:page standardController="Volunteer_Job__c" title="{!$Label.labelMassEmailVolunteersTitle}" tabStyle="Task" >
+    <apex:include pageName="SendBulkEmail"/>
+</apex:page>

--- a/src/pages/SendBulkEmail_Job.page-meta.xml
+++ b/src/pages/SendBulkEmail_Job.page-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>37.0</apiVersion>
+    <availableInTouch>false</availableInTouch>
+    <confirmationTokenRequired>false</confirmationTokenRequired>
+    <label>SendBulkEmail_Job</label>
+</ApexPage>

--- a/src/pages/SendBulkEmail_Job.page-meta.xml
+++ b/src/pages/SendBulkEmail_Job.page-meta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>37.0</apiVersion>
-    <availableInTouch>false</availableInTouch>
+    <apiVersion>31.0</apiVersion>
+    <availableInTouch>true</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>SendBulkEmail_Job</label>
 </ApexPage>

--- a/src/pages/SendBulkEmail_Shift.page
+++ b/src/pages/SendBulkEmail_Shift.page
@@ -1,0 +1,32 @@
+<!-- 
+    Copyright (c) 2016, salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    3. Neither the name of Salesforce.org nor the names of
+       its contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+-->
+<apex:page standardController="Volunteer_Shift__c" title="{!$Label.labelMassEmailVolunteersTitle}" tabStyle="Task" >
+    <apex:include pageName="SendBulkEmail"/>
+</apex:page>

--- a/src/pages/SendBulkEmail_Shift.page-meta.xml
+++ b/src/pages/SendBulkEmail_Shift.page-meta.xml
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>SendBulkEmail_Shift</fullName>
-    <apiVersion>37.0</apiVersion>
-    <description></description>
+    <apiVersion>31.0</apiVersion>
+    <availableInTouch>true</availableInTouch>
+    <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>SendBulkEmail_Shift</label>
 </ApexPage>

--- a/src/pages/SendBulkEmail_Shift.page-meta.xml
+++ b/src/pages/SendBulkEmail_Shift.page-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>SendBulkEmail_Shift</fullName>
+    <apiVersion>37.0</apiVersion>
+    <description></description>
+    <label>SendBulkEmail_Shift</label>
+</ApexPage>

--- a/src/pages/VolunteersFind_Campaign.page
+++ b/src/pages/VolunteersFind_Campaign.page
@@ -1,0 +1,32 @@
+<!-- 
+    Copyright (c) 2016, salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    3. Neither the name of Salesforce.org nor the names of
+       its contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+-->
+<apex:page standardController="Campaign" tabStyle="Find_Volunteers__tab" >
+    <apex:include pageName="VolunteersFind"/>
+</apex:page>

--- a/src/pages/VolunteersFind_Campaign.page-meta.xml
+++ b/src/pages/VolunteersFind_Campaign.page-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>31.0</apiVersion>
+    <availableInTouch>false</availableInTouch>
+    <confirmationTokenRequired>false</confirmationTokenRequired>
+    <label>VolunteersFind_Campaign</label>
+</ApexPage>

--- a/src/pages/VolunteersFind_Job.page
+++ b/src/pages/VolunteersFind_Job.page
@@ -1,0 +1,32 @@
+<!-- 
+    Copyright (c) 2016, salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    3. Neither the name of Salesforce.org nor the names of
+       its contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+-->
+<apex:page standardController="Volunteer_Job__c" tabStyle="Find_Volunteers__tab" >
+    <apex:include pageName="VolunteersFind"/>
+</apex:page>

--- a/src/pages/VolunteersFind_Job.page-meta.xml
+++ b/src/pages/VolunteersFind_Job.page-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>31.0</apiVersion>
+    <availableInTouch>true</availableInTouch>
+    <confirmationTokenRequired>false</confirmationTokenRequired>
+    <label>VolunteersFind_Job</label>
+</ApexPage>

--- a/src/pages/VolunteersFind_Shift.page
+++ b/src/pages/VolunteersFind_Shift.page
@@ -1,0 +1,32 @@
+<!-- 
+    Copyright (c) 2016, salesforce.org
+    All rights reserved.
+    
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    3. Neither the name of Salesforce.org nor the names of
+       its contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    POSSIBILITY OF SUCH DAMAGE.
+-->
+<apex:page standardController="Volunteer_Shift__c" tabStyle="Find_Volunteers__tab" >
+    <apex:include pageName="VolunteersFind"/>
+</apex:page>

--- a/src/pages/VolunteersFind_Shift.page-meta.xml
+++ b/src/pages/VolunteersFind_Shift.page-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>31.0</apiVersion>
+    <availableInTouch>true</availableInTouch>
+    <confirmationTokenRequired>false</confirmationTokenRequired>
+    <label>VolunteersFind_Shift</label>
+</ApexPage>


### PR DESCRIPTION
# Critical Changes
- Enables Mass Email Volunteers, Find Volunteers buttons to work under Lightning Experience.  Admins must enable the following visualforce pages for all profiles who use Volunteers for Salesforce:
* SendBulkEmail_Campaign, SendBulkEmail_Job, SendBulkEmail_Shift
* VolunteersFind_Campaign, VolunteersFind_Job, VolunteersFind_Shift

# Changes


# Issues Closed