### PR TITLE
Feature/metadatachanges

### DIFF
--- a/src/classes/VOL_SharedCode.cls
+++ b/src/classes/VOL_SharedCode.cls
@@ -807,6 +807,25 @@ global with sharing class VOL_SharedCode {
         );
         return new List<Id>(campaignsInHierarchy.keySet());
     }
+    
+    /*******************************************************************************************************
+    * @description keeps references to old labels that have been packaged, that we no longer use.
+    * @return void
+    ********************************************************************************************************/
+    private static void keepUnusedLabelsInPackage() {
+        string str;
+        str = Label.labelCalendarConfirmed;
+        str = Label.labelContactInfoRankText;
+        str = Label.labelHide;
+        str = Label.labelMassEmailHelp1;
+        str = Label.labelMassEmailHelp2;
+        str = Label.labelMassEmailHelp3;
+        str = Label.labelMassEmailHelp4;
+        str = Label.labelMassEmailHelp5;
+        str = Label.labelMassEmailHelp6;
+        str = Label.labelMassEmailHelp7;
+        str = Label.labelShowHelp;
+    }
 
      
 }

--- a/src/dashboards/Volunteer_Dashboards/Panel_de_Voluntarios.dashboard
+++ b/src/dashboards/Volunteer_Dashboards/Panel_de_Voluntarios.dashboard
@@ -19,7 +19,6 @@
             <indicatorMiddleColor>#C2C254</indicatorMiddleColor>
             <maxValuesDisplayed>50</maxValuesDisplayed>
             <report>Volunteer_Reports/Top_Volunteers_by_Lifetime_Hours</report>
-            <showPicturesOnTables>true</showPicturesOnTables>
             <sortBy>RowValueDescending</sortBy>
             <title>Top Voluntarios por Horas Trabajadas</title>
         </components>
@@ -35,7 +34,6 @@
             <indicatorMiddleColor>#C2C254</indicatorMiddleColor>
             <maxValuesDisplayed>20</maxValuesDisplayed>
             <report>Volunteer_Reports/Top_Volunteers_by_Recent_Hours</report>
-            <showPicturesOnTables>true</showPicturesOnTables>
             <sortBy>RowValueDescending</sortBy>
             <title>Top Voluntarios por Horas Trabajadas Rec</title>
         </components>
@@ -49,7 +47,6 @@
             <indicatorLowColor>#C25454</indicatorLowColor>
             <indicatorMiddleColor>#C2C254</indicatorMiddleColor>
             <report>Volunteer_Reports/Volunteers_Last_Month</report>
-            <showPicturesOnTables>true</showPicturesOnTables>
             <sortBy>RowLabelAscending</sortBy>
             <title>Voluntarios con Horas trabajadas el Mes</title>
         </components>
@@ -146,7 +143,7 @@
             <useReportChart>false</useReportChart>
         </components>
     </rightSection>
-    <runningUser>davidhabibvol@groundwire.org</runningUser>
+    <runningUser>dhabib@v4s.dev</runningUser>
     <textColor>#000000</textColor>
     <title>Panel de Voluntarios</title>
     <titleColor>#000000</titleColor>

--- a/src/dashboards/Volunteer_Dashboards/Volunteers_Dashboard2.dashboard
+++ b/src/dashboards/Volunteer_Dashboards/Volunteers_Dashboard2.dashboard
@@ -19,7 +19,6 @@
             <indicatorMiddleColor>#C2C254</indicatorMiddleColor>
             <maxValuesDisplayed>50</maxValuesDisplayed>
             <report>Volunteer_Reports/Top_Volunteers_by_Lifetime_Hours</report>
-            <showPicturesOnTables>true</showPicturesOnTables>
             <sortBy>RowValueDescending</sortBy>
             <title>Top Volunteers by Lifetime Hours</title>
         </components>
@@ -35,7 +34,6 @@
             <indicatorMiddleColor>#C2C254</indicatorMiddleColor>
             <maxValuesDisplayed>20</maxValuesDisplayed>
             <report>Volunteer_Reports/Top_Volunteers_by_Recent_Hours</report>
-            <showPicturesOnTables>true</showPicturesOnTables>
             <sortBy>RowValueDescending</sortBy>
             <title>Top Volunteers by Recent Hours</title>
         </components>
@@ -49,7 +47,6 @@
             <indicatorLowColor>#C25454</indicatorLowColor>
             <indicatorMiddleColor>#C2C254</indicatorMiddleColor>
             <report>Volunteer_Reports/Volunteers_Last_Month</report>
-            <showPicturesOnTables>true</showPicturesOnTables>
             <sortBy>RowLabelAscending</sortBy>
             <title>Volunteers Last Month</title>
         </components>
@@ -146,7 +143,7 @@
             <useReportChart>false</useReportChart>
         </components>
     </rightSection>
-    <runningUser>davidhabibvol@groundwire.org</runningUser>
+    <runningUser>dhabib@v4s.dev</runningUser>
     <textColor>#000000</textColor>
     <title>Volunteers Dashboard</title>
     <titleColor>#000000</titleColor>

--- a/src/objects/Campaign.object
+++ b/src/objects/Campaign.object
@@ -72,7 +72,6 @@
     </fieldSets>
     <fields>
         <fullName>Number_of_Volunteers__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>The total number of volunteers whose Hours Status = Completed or Confirmed.</inlineHelpText>
         <label>Number of Volunteers</label>
@@ -83,7 +82,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Completed_Hours__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Total number of hours that are completed.  Hours with other status values are not included.</inlineHelpText>
         <label>Volunteer Completed Hours</label>
@@ -94,7 +92,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Jobs__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteer Jobs</label>
         <summaryForeignKey>Volunteer_Job__c.Campaign__c</summaryForeignKey>
@@ -103,7 +100,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Shifts__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteer Shifts</label>
         <summarizedField>Volunteer_Job__c.Number_of_Shifts__c</summarizedField>
@@ -113,7 +109,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Website_Time_Zone__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>The Time Zone to use when displaying Shift times on Sites pages.  You only need to set this if you want to override the Time Zone set on the Site Guest User profile.</inlineHelpText>
         <label>Volunteer Website Time Zone</label>
@@ -477,7 +472,6 @@
     </fields>
     <fields>
         <fullName>Volunteers_Still_Needed__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteers Still Needed</label>
         <summarizedField>Volunteer_Job__c.Number_of_Volunteers_Still_Needed__c</summarizedField>

--- a/src/objects/Contact.object
+++ b/src/objects/Contact.object
@@ -1897,7 +1897,6 @@
     </fieldSets>
     <fields>
         <fullName>First_Volunteer_Date__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>The first Volunteer Hours Start Date</inlineHelpText>
         <label>First Volunteer Date</label>
@@ -1913,7 +1912,6 @@
     </fields>
     <fields>
         <fullName>Last_Volunteer_Date__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>The latest Volunteer Hours End Date</inlineHelpText>
         <label>Last Volunteer Date</label>
@@ -1929,7 +1927,6 @@
     </fields>
     <fields>
         <fullName>Unique_Volunteer_Count__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>1</formula>
         <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
@@ -1943,7 +1940,6 @@
     <fields>
         <fullName>Volunteer_Auto_Reminder_Email_Opt_Out__c</fullName>
         <defaultValue>false</defaultValue>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Check if this Contact does not want to receive automatic reminder emails about their upcoming shifts.  Used in the &quot;Volunteer Hours Reminder Email&quot; workflow rule.</inlineHelpText>
         <label>Volunteer Auto-Reminder Email Opt Out</label>
@@ -1952,7 +1948,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Availability__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteer Availability</label>
         <picklist>
@@ -1985,7 +1980,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Hours__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Total number of Hours that are Completed. Hours with other status values are not included.</inlineHelpText>
         <label>Volunteer Hours</label>
@@ -2001,7 +1995,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Last_Web_Signup_Date__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>The date of the most recent volunteer signup from the web.  Used to trigger workflow for notifications and thank you emails.</inlineHelpText>
         <label>Volunteer Last Web Signup Date</label>
@@ -2011,7 +2004,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Manager_Notes__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Notes about the volunteer that the volunteer manager or organization staff want to record.</inlineHelpText>
         <label>Volunteer Manager Notes</label>
@@ -2022,7 +2014,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Notes__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Notes from the volunteer.  Note that the web signup form appends the volunteers comments to this field.</inlineHelpText>
         <label>Volunteer Notes</label>
@@ -2033,7 +2024,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Organization__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>The organization, company, or group the contact is volunteering on behalf of.</inlineHelpText>
         <label>Volunteer Organization</label>
@@ -2045,7 +2035,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Skills__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Select the skill(s) this contact has that should be used to find volunteer jobs.</inlineHelpText>
         <label>Volunteer Skills</label>
@@ -2083,7 +2072,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Status__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteer Status</label>
         <picklist>

--- a/src/objects/Job_Recurrence_Schedule__c.object
+++ b/src/objects/Job_Recurrence_Schedule__c.object
@@ -21,6 +21,10 @@
         <type>Default</type>
     </actionOverrides>
     <actionOverrides>
+        <actionName>Follow</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
         <actionName>List</actionName>
         <type>Default</type>
     </actionOverrides>
@@ -43,7 +47,6 @@
     <allowInChatterGroups>false</allowInChatterGroups>
     <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
-    <deprecated>false</deprecated>
     <enableActivities>false</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableEnhancedLookup>false</enableEnhancedLookup>
@@ -55,7 +58,6 @@
     <enableStreamingApi>true</enableStreamingApi>
     <fields>
         <fullName>Days_of_Week__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Days of Week</label>
         <picklist>
@@ -96,7 +98,6 @@
     </fields>
     <fields>
         <fullName>Description__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Description text to copy to shift records created on this schedule.</inlineHelpText>
         <label>Description</label>
@@ -107,7 +108,6 @@
     </fields>
     <fields>
         <fullName>Desired_Number_of_Volunteers__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Desired Number of Volunteers</label>
         <precision>6</precision>
@@ -119,7 +119,6 @@
     </fields>
     <fields>
         <fullName>Duration__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Duration</label>
         <precision>5</precision>
@@ -131,7 +130,6 @@
     </fields>
     <fields>
         <fullName>Schedule_End_Date__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Schedule End Date</label>
         <required>false</required>
@@ -140,7 +138,6 @@
     </fields>
     <fields>
         <fullName>Schedule_Start_Date_Time__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Schedule Start Date &amp; Time</label>
         <required>true</required>
@@ -149,7 +146,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Job__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>The Job this Recurrence Schedule is for.</inlineHelpText>
         <label>Volunteer Job</label>
@@ -163,7 +159,6 @@
     </fields>
     <fields>
         <fullName>Weekly_Occurrence__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Weekly Occurrence</label>
         <picklist>

--- a/src/objects/Lead.object
+++ b/src/objects/Lead.object
@@ -2,7 +2,6 @@
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
     <fields>
         <fullName>Volunteer_Availability__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteer Availability</label>
         <picklist>
@@ -35,7 +34,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Notes__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteer Notes</label>
         <length>32000</length>
@@ -45,7 +43,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Skills__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Select the skill(s) this person has that should be used to find volunteer jobs.</inlineHelpText>
         <label>Volunteer Skills</label>
@@ -83,7 +80,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Status__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteer Status</label>
         <picklist>

--- a/src/objects/Volunteer_Hours__c.object
+++ b/src/objects/Volunteer_Hours__c.object
@@ -21,6 +21,10 @@
         <type>Default</type>
     </actionOverrides>
     <actionOverrides>
+        <actionName>Follow</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
         <actionName>List</actionName>
         <type>Default</type>
     </actionOverrides>
@@ -43,7 +47,6 @@
     <allowInChatterGroups>false</allowInChatterGroups>
     <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
-    <deprecated>false</deprecated>
     <enableActivities>true</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableFeeds>false</enableFeeds>
@@ -429,7 +432,6 @@
     </fieldSets>
     <fields>
         <fullName>Comments__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Comments</label>
         <length>32000</length>
@@ -439,7 +441,6 @@
     </fields>
     <fields>
         <fullName>Contact__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Contact</label>
         <referenceTo>Contact</referenceTo>
@@ -453,7 +454,6 @@
     </fields>
     <fields>
         <fullName>End_Date__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>End Date</label>
         <required>false</required>
@@ -462,7 +462,6 @@
     </fields>
     <fields>
         <fullName>Full_Name__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>Contact__r.LastName  &amp; &quot;, &quot; &amp;  Contact__r.FirstName</formula>
         <label>Full Name</label>
@@ -473,7 +472,6 @@
     </fields>
     <fields>
         <fullName>Hours_Worked__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Hours Worked</label>
         <precision>7</precision>
@@ -486,7 +484,6 @@
     <fields>
         <fullName>Number_of_Volunteers__c</fullName>
         <defaultValue>1</defaultValue>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Defaults to 1. Increase if this person is bringing additional people whom you are not directly tracking as contacts, and won&apos;t be logging individual volunteer hours against.</inlineHelpText>
         <label>Number of Volunteers</label>
@@ -499,7 +496,6 @@
     </fields>
     <fields>
         <fullName>Planned_Start_Date_Time__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>The actual date &amp; time the volunteer is planning on starting.</inlineHelpText>
         <label>Planned Start Date &amp; Time</label>
@@ -509,7 +505,6 @@
     </fields>
     <fields>
         <fullName>Shift_Start_Date_Time__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>Volunteer_Shift__r.Start_Date_Time__c</formula>
         <label>Shift Start Date &amp; Time</label>
@@ -519,7 +514,6 @@
     </fields>
     <fields>
         <fullName>Start_Date__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Start Date</label>
         <required>true</required>
@@ -528,7 +522,6 @@
     </fields>
     <fields>
         <fullName>Status__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Status</label>
         <picklist>
@@ -564,7 +557,6 @@
     </fields>
     <fields>
         <fullName>System_Note__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Text information from the system scheduler.</inlineHelpText>
         <label>System Note</label>
@@ -574,7 +566,6 @@
     </fields>
     <fields>
         <fullName>Total_Hours_Worked__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>IF( ISPICKVAL(Status__c, &quot;Completed&quot;), Hours_Worked__c *  Number_of_Volunteers__c, null)</formula>
         <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
@@ -588,7 +579,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Campaign_Name__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>Volunteer_Job__r.Campaign__r.Name</formula>
         <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
@@ -600,7 +590,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Campaign__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>Volunteer_Job__r.Campaign__c</formula>
         <label>Volunteer Campaign</label>
@@ -611,7 +600,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Job__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteer Job</label>
         <referenceTo>Volunteer_Job__c</referenceTo>
@@ -626,7 +614,6 @@
     <fields>
         <fullName>Volunteer_Recurrence_Schedule__c</fullName>
         <deleteConstraint>SetNull</deleteConstraint>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteer Recurrence Schedule</label>
         <referenceTo>Volunteer_Recurrence_Schedule__c</referenceTo>
@@ -639,7 +626,6 @@
     <fields>
         <fullName>Volunteer_Shift__c</fullName>
         <deleteConstraint>SetNull</deleteConstraint>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteer Shift</label>
         <lookupFilter>

--- a/src/objects/Volunteer_Job__c.object
+++ b/src/objects/Volunteer_Job__c.object
@@ -21,6 +21,10 @@
         <type>Default</type>
     </actionOverrides>
     <actionOverrides>
+        <actionName>Follow</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
         <actionName>List</actionName>
         <type>Default</type>
     </actionOverrides>
@@ -43,7 +47,6 @@
     <allowInChatterGroups>false</allowInChatterGroups>
     <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
-    <deprecated>false</deprecated>
     <enableActivities>true</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableFeeds>false</enableFeeds>
@@ -54,7 +57,6 @@
     <enableStreamingApi>true</enableStreamingApi>
     <fields>
         <fullName>Campaign__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Campaign</label>
         <referenceTo>Campaign</referenceTo>
@@ -68,7 +70,6 @@
     </fields>
     <fields>
         <fullName>Description__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Description</label>
         <length>32000</length>
@@ -79,7 +80,6 @@
     <fields>
         <fullName>Display_on_Website__c</fullName>
         <defaultValue>false</defaultValue>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Check this field if this Volunteer Job should be included in the Available Volunteer Jobs Sites page.</inlineHelpText>
         <label>Display on Website</label>
@@ -88,7 +88,6 @@
     </fields>
     <fields>
         <fullName>External_Signup_Url__c</fullName>
-        <deprecated>false</deprecated>
         <description>If provided, the VolunteersJobListingFS page will redirect to this website when the user clicks on the Sign Up link on the page.  This allows you to advertise jobs that one must register for on another web site.</description>
         <externalId>false</externalId>
         <inlineHelpText>If provided, the VolunteersJobListingFS page will redirect to this website when the user clicks on the Sign Up link on the page.  This allows you to advertise jobs that one must register for on another web site.</inlineHelpText>
@@ -101,7 +100,6 @@
     </fields>
     <fields>
         <fullName>First_Shift__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>First Shift</label>
         <summarizedField>Volunteer_Shift__c.Start_Date_Time__c</summarizedField>
@@ -113,7 +111,6 @@
     <fields>
         <fullName>Inactive__c</fullName>
         <defaultValue>false</defaultValue>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Check if this Volunteer Job is no longer active, and it won&apos;t be included in the Volunteers Report Hours Sites page.</inlineHelpText>
         <label>Inactive</label>
@@ -122,7 +119,6 @@
     </fields>
     <fields>
         <fullName>Location_City__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Location City</label>
         <length>255</length>
@@ -133,7 +129,6 @@
     </fields>
     <fields>
         <fullName>Location_Information__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Put in any additional details, like driving directions or a URL to a map, in this field, and it will be included in automated email reminders.</inlineHelpText>
         <label>Location Information</label>
@@ -144,7 +139,6 @@
     </fields>
     <fields>
         <fullName>Location_Street__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Location Street</label>
         <length>255</length>
@@ -155,7 +149,6 @@
     </fields>
     <fields>
         <fullName>Location_Zip_Postal_Code__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Location Zip/Postal Code</label>
         <length>100</length>
@@ -166,7 +159,6 @@
     </fields>
     <fields>
         <fullName>Location__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Location State/Province</label>
         <length>100</length>
@@ -177,7 +169,6 @@
     </fields>
     <fields>
         <fullName>Number_of_Completed_Hours__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Total number of Hours that are Completed.  Hours with other status values are not included.</inlineHelpText>
         <label>Number of Completed Hours</label>
@@ -194,7 +185,6 @@
     </fields>
     <fields>
         <fullName>Number_of_Shifts__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Number of Shifts</label>
         <summaryForeignKey>Volunteer_Shift__c.Volunteer_Job__c</summaryForeignKey>
@@ -204,7 +194,6 @@
     </fields>
     <fields>
         <fullName>Number_of_Volunteers_Still_Needed__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label># of Volunteers Still Needed</label>
         <summarizedField>Volunteer_Shift__c.Number_of_Volunteers_Still_Needed__c</summarizedField>
@@ -215,7 +204,6 @@
     </fields>
     <fields>
         <fullName>Number_of_Volunteers__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>The total number of volunteers whose Hours Status = Completed or Confirmed.</inlineHelpText>
         <label>Number of Volunteers</label>
@@ -233,7 +221,6 @@
     <fields>
         <fullName>Ongoing__c</fullName>
         <defaultValue>false</defaultValue>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Ongoing</label>
         <trackTrending>false</trackTrending>
@@ -241,7 +228,6 @@
     </fields>
     <fields>
         <fullName>Skills_Needed__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>the skills the volunteer should have to do this job</inlineHelpText>
         <label>Skills Needed</label>
@@ -283,7 +269,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Website_Time_Zone__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>The Time Zone to use when displaying Shift times on Sites pages.   You only need to set this if you want to override both the Time Zone set on the Site Guest User profile, and the Time Zone set on the Volunteers campaign.</inlineHelpText>
         <label>Volunteer Website Time Zone</label>

--- a/src/objects/Volunteer_Recurrence_Schedule__c.object
+++ b/src/objects/Volunteer_Recurrence_Schedule__c.object
@@ -23,6 +23,10 @@
         <type>Visualforce</type>
     </actionOverrides>
     <actionOverrides>
+        <actionName>Follow</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
         <actionName>List</actionName>
         <type>Default</type>
     </actionOverrides>
@@ -47,7 +51,6 @@
     <allowInChatterGroups>false</allowInChatterGroups>
     <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
-    <deprecated>false</deprecated>
     <enableActivities>false</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableEnhancedLookup>false</enableEnhancedLookup>
@@ -139,7 +142,6 @@
     </fieldSets>
     <fields>
         <fullName>Comments__c</fullName>
-        <deprecated>false</deprecated>
         <description>Text that will get copied to the Volunteer Hours Comment field for all Hours created by this Volunteer Recurrence Schedule.</description>
         <externalId>false</externalId>
         <inlineHelpText>Text that will get copied to the Volunteer Hours Comment field for all Hours created by this Volunteer Recurrence Schedule.</inlineHelpText>
@@ -151,7 +153,6 @@
     </fields>
     <fields>
         <fullName>Contact__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Contact</label>
         <referenceTo>Contact</referenceTo>
@@ -165,7 +166,6 @@
     </fields>
     <fields>
         <fullName>Days_of_Week__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Days of Week</label>
         <picklist>
@@ -206,7 +206,6 @@
     </fields>
     <fields>
         <fullName>Duration__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Duration</label>
         <precision>4</precision>
@@ -219,7 +218,6 @@
     <fields>
         <fullName>Number_of_Volunteers__c</fullName>
         <defaultValue>1</defaultValue>
-        <deprecated>false</deprecated>
         <description>Set to 1 for an individual.  Set to a larger number if the Contact represents a group, and you will not be tracking each individual&apos;s hours.</description>
         <externalId>false</externalId>
         <inlineHelpText>Set to 1 for an individual.  Set to a larger number if the Contact represents a group, and you will not be tracking each individual&apos;s hours.</inlineHelpText>
@@ -233,7 +231,6 @@
     </fields>
     <fields>
         <fullName>Schedule_End_Date__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Schedule End Date</label>
         <required>false</required>
@@ -242,7 +239,6 @@
     </fields>
     <fields>
         <fullName>Schedule_Start_Date_Time__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Schedule Start Date &amp; Time</label>
         <required>true</required>
@@ -251,7 +247,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Hours_Status__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>The Volunteer Hours Status value to specify on newly created Hours records.</inlineHelpText>
         <label>Volunteer Hours Status</label>
@@ -281,7 +276,6 @@
     <fields>
         <fullName>Volunteer_Job__c</fullName>
         <deleteConstraint>SetNull</deleteConstraint>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteer Job</label>
         <referenceTo>Volunteer_Job__c</referenceTo>
@@ -293,7 +287,6 @@
     </fields>
     <fields>
         <fullName>Weekly_Occurrence__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Weekly Occurrence</label>
         <picklist>

--- a/src/objects/Volunteer_Shift__c.object
+++ b/src/objects/Volunteer_Shift__c.object
@@ -21,6 +21,10 @@
         <type>Default</type>
     </actionOverrides>
     <actionOverrides>
+        <actionName>Follow</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
         <actionName>List</actionName>
         <type>Default</type>
     </actionOverrides>
@@ -43,7 +47,6 @@
     <allowInChatterGroups>false</allowInChatterGroups>
     <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
-    <deprecated>false</deprecated>
     <enableActivities>true</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableFeeds>false</enableFeeds>
@@ -54,7 +57,6 @@
     <enableStreamingApi>true</enableStreamingApi>
     <fields>
         <fullName>Description__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Description</label>
         <length>32000</length>
@@ -64,7 +66,6 @@
     </fields>
     <fields>
         <fullName>Desired_Number_of_Volunteers__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Desired # of Volunteers</label>
         <precision>5</precision>
@@ -76,7 +77,6 @@
     </fields>
     <fields>
         <fullName>Duration__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>How many hours long is the shift?</inlineHelpText>
         <label>Duration (Hours)</label>
@@ -89,7 +89,6 @@
     </fields>
     <fields>
         <fullName>Job_Location_City__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>Volunteer_Job__r.Location_City__c</formula>
         <label>Job Location City</label>
@@ -100,7 +99,6 @@
     </fields>
     <fields>
         <fullName>Job_Location_State_Province__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>Volunteer_Job__r.Location__c</formula>
         <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
@@ -112,7 +110,6 @@
     </fields>
     <fields>
         <fullName>Job_Location_Street__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>Volunteer_Job__r.Location_Street__c</formula>
         <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
@@ -124,7 +121,6 @@
     </fields>
     <fields>
         <fullName>Job_Location_Zip_Postal_Code__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>Volunteer_Job__r.Location_Zip_Postal_Code__c</formula>
         <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
@@ -137,7 +133,6 @@
     <fields>
         <fullName>Job_Recurrence_Schedule__c</fullName>
         <deleteConstraint>SetNull</deleteConstraint>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Automatically set by the system scheduler to show the Job Recurrence Schedule this shift is associated with.</inlineHelpText>
         <label>Job Recurrence Schedule</label>
@@ -150,7 +145,6 @@
     </fields>
     <fields>
         <fullName>Number_of_Volunteers_Still_Needed__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <formula>max ( 0, Desired_Number_of_Volunteers__c -  BLANKVALUE(Total_Volunteers__c, 0))</formula>
         <label># of Volunteers Still Needed</label>
@@ -163,7 +157,6 @@
     </fields>
     <fields>
         <fullName>Start_Date_Time__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Start Date &amp; Time</label>
         <required>true</required>
@@ -172,7 +165,6 @@
     </fields>
     <fields>
         <fullName>System_Note__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Text information from the system scheduler.</inlineHelpText>
         <label>System Note</label>
@@ -184,7 +176,6 @@
     </fields>
     <fields>
         <fullName>Total_Volunteers__c</fullName>
-        <deprecated>false</deprecated>
         <description>This field is maintained by the VOL_VolunteerHours_ShiftRollups trigger.</description>
         <externalId>false</externalId>
         <inlineHelpText>SYSTEM FIELD.  DO NOT EDIT.  The total number of volunteers whose Hours Status = Completed or Confirmed.</inlineHelpText>
@@ -198,7 +189,6 @@
     </fields>
     <fields>
         <fullName>Volunteer_Job__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <label>Volunteer Job</label>
         <referenceTo>Volunteer_Job__c</referenceTo>

--- a/src/objects/Volunteers_Settings__c.object
+++ b/src/objects/Volunteers_Settings__c.object
@@ -5,7 +5,6 @@
     <enableFeeds>false</enableFeeds>
     <fields>
         <fullName>Contact_Match_Email_Fields__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>A semicolon separated list of additional Contact email fields to try to match against when doing Contact matching. Note that the fields are specified by their full Developer name, including namespace prefix. NPSP email fields are automatically checked.</inlineHelpText>
         <label>Contact Match Email Fields</label>
@@ -17,7 +16,6 @@
     </fields>
     <fields>
         <fullName>Contact_Match_First_Name_Fields__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>A semicolon separated list of additional Contact first name fields to try to match against when doing Contact matching. E.g., a nickname field.  Note that the fields are specified by their full Developer name, including namespace prefix.</inlineHelpText>
         <label>Contact Match First Name Fields</label>
@@ -30,7 +28,6 @@
     <fields>
         <fullName>Contact_Matching_Rule__c</fullName>
         <defaultValue>&quot;Firstname;Lastname;Email&quot;</defaultValue>
-        <deprecated>false</deprecated>
         <description>Specifies which rule to follow when trying to match Contacts against existing Contacts from the Volunteers Sites pages. Semicolon separated string containing one or more of the fields Firstname, Lastname, and Email.</description>
         <externalId>false</externalId>
         <inlineHelpText>Specifies which rule to follow when trying to match Contacts against existing Contacts from the Volunteers Sites pages. Semicolon separated string containing one or more of the fields Firstname, Lastname, and Email.</inlineHelpText>
@@ -43,7 +40,6 @@
     </fields>
     <fields>
         <fullName>Google_Maps_API_Key__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>If you include a Google Maps API Key, the JobListing pages will display a map on your volunteers site for the Job Location.</inlineHelpText>
         <label>Google Maps API Key</label>
@@ -55,7 +51,6 @@
     </fields>
     <fields>
         <fullName>Personal_Site_Org_Wide_Email_Name__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>The Display Name of the Organization-Wide Email Address to use on the email sent from the PersonalSiteContactLookup Sites page.</inlineHelpText>
         <label>Personal Site Org-Wide Email Name</label>
@@ -68,7 +63,6 @@
     <fields>
         <fullName>Personal_Site_Report_Hours_Filtered__c</fullName>
         <defaultValue>false</defaultValue>
-        <deprecated>false</deprecated>
         <description>Personal Site Report Hours Filter By Contact</description>
         <externalId>false</externalId>
         <inlineHelpText>Personal Site Report Hours Filter By Contact</inlineHelpText>
@@ -79,7 +73,6 @@
     <fields>
         <fullName>Personal_Site_Requires_URL_Email_Match__c</fullName>
         <defaultValue>false</defaultValue>
-        <deprecated>false</deprecated>
         <description>If checked, then the Personal Site requires the Email URL parameter is included and matches an Email field on the specified Contact.</description>
         <externalId>false</externalId>
         <inlineHelpText>If checked, then the Personal Site requires the Email URL parameter is included and matches an Email field on the specified Contact.</inlineHelpText>
@@ -90,7 +83,6 @@
     <fields>
         <fullName>Recurring_Job_Future_Months__c</fullName>
         <defaultValue>4</defaultValue>
-        <deprecated>false</deprecated>
         <description>How many months into the future should Recurring Job Shifts be scheduled?  If this number is too large, you may run into Salesforce CPU time limits which will prevent the Job Scheduler from running completely.  It is recommended to use 4 months or less.</description>
         <externalId>false</externalId>
         <inlineHelpText>How many months into the future should Recurring Job Shifts be scheduled?  If this number is too large, you may run into Salesforce CPU time limits which will prevent the Job Scheduler from running completely.  It is recommended to use 4 months or less.</inlineHelpText>
@@ -104,7 +96,6 @@
     </fields>
     <fields>
         <fullName>Signup_Bucket_Account_On_Create__c</fullName>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>The name of the account to use when creating new Contacts during Signup.  If you are using the Non Profit Start Pack One-to-One model, leave this setting blank.  If you are using the bucket model, set this to the name of the account; usually &apos;Individual&apos;.</inlineHelpText>
         <label>Signup Bucket Account On Create</label>
@@ -117,7 +108,6 @@
     <fields>
         <fullName>Signup_Creates_Contacts_If_No_Match__c</fullName>
         <defaultValue>false</defaultValue>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Should the Volunteer Signup form create new Contact records, if no existing contact is found (or Signup Matches Existing Contacts is unchecked).  If this setting is unchecked, it will create Leads when no matches found.</inlineHelpText>
         <label>Signup Creates Contacts If No Match</label>
@@ -127,7 +117,6 @@
     <fields>
         <fullName>Signup_Matches_Existing_Contacts__c</fullName>
         <defaultValue>false</defaultValue>
-        <deprecated>false</deprecated>
         <externalId>false</externalId>
         <inlineHelpText>Should the Volunteer Signup page try to match the person to an existing Contact (by First Name, Last Name, Email).</inlineHelpText>
         <label>Signup Matches Existing Contacts</label>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Volunteers+for+Salesforce</fullName>
+    <fullName>Volunteers for Salesforce</fullName>
     <types>
         <members>ComponentControllerBase</members>
         <members>PageControllerBase</members>
@@ -652,9 +652,9 @@
     <types>
         <members>Contact.Volunteer Signup - Contact</members>
         <members>Lead.Volunteer Signup - Lead</members>
-        <members>Volunteer_Hours__c.Volunteer Hours Reminder Email</members>
         <members>Volunteer_Hours__c.Volunteer Hours - Set End Date</members>
         <members>Volunteer_Hours__c.Volunteer Hours - Set Planned Start Date %26 Time</members>
+        <members>Volunteer_Hours__c.Volunteer Hours Reminder Email</members>
         <members>Volunteer_Hours__c.Volunteer Job Signup</members>
         <name>WorkflowRule</name>
     </types>
@@ -663,5 +663,5 @@
         <members>Lead.Volunteer_Signup_Thank_You_Sent_Lead</members>
         <name>WorkflowTask</name>
     </types>
-    <version>38.0</version>
+    <version>36.0</version>
 </Package>

--- a/src/translations/de.translation
+++ b/src/translations/de.translation
@@ -556,6 +556,22 @@ Tag:      &apos;Tag&apos;</label>
         <name>labelTitleJobSignup</name>
     </customLabels>
     <customLabels>
+        <label><!-- labelVRSBatchDescription --></label>
+        <name>labelVRSBatchDescription</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVRSBatchProcess --></label>
+        <name>labelVRSBatchProcess</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVRSBatchProcessProgress --></label>
+        <name>labelVRSBatchProcessProgress</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVRSBatchRun --></label>
+        <name>labelVRSBatchRun</name>
+    </customLabels>
+    <customLabels>
         <label>Automatisch für Zeitplan für wiederkehrende Freiwillige erstellt:</label>
         <name>labelVRSHoursCreatedSystemNote</name>
     </customLabels>
@@ -578,6 +594,38 @@ Tag:      &apos;Tag&apos;</label>
     <customLabels>
         <label>Vielen Dank für Ihre Anmeldung als Freiwilliger.</label>
         <name>labelVolunteerSignupThankYou</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelp --></label>
+        <name>labelVolunteersHelp</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpDescription --></label>
+        <name>labelVolunteersHelpDescription</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep1 --></label>
+        <name>labelVolunteersHelpStep1</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep1Text --></label>
+        <name>labelVolunteersHelpStep1Text</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep2 --></label>
+        <name>labelVolunteersHelpStep2</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep2Text --></label>
+        <name>labelVolunteersHelpStep2Text</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep3 --></label>
+        <name>labelVolunteersHelpStep3</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep3Text --></label>
+        <name>labelVolunteersHelpStep3Text</name>
     </customLabels>
     <customLabels>
         <label>Für diese Schicht werden nur noch {0} Freiwillige gesucht.</label>

--- a/src/translations/en_US.translation
+++ b/src/translations/en_US.translation
@@ -549,6 +549,22 @@
         <name>labelTitleJobSignup</name>
     </customLabels>
     <customLabels>
+        <label><!-- labelVRSBatchDescription --></label>
+        <name>labelVRSBatchDescription</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVRSBatchProcess --></label>
+        <name>labelVRSBatchProcess</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVRSBatchProcessProgress --></label>
+        <name>labelVRSBatchProcessProgress</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVRSBatchRun --></label>
+        <name>labelVRSBatchRun</name>
+    </customLabels>
+    <customLabels>
         <label><!-- System Note added to Hour when created by a VRS. --></label>
         <name>labelVRSHoursCreatedSystemNote</name>
     </customLabels>
@@ -571,6 +587,38 @@
     <customLabels>
         <label><!-- Thank you message displayed after a successful Volunteer Signup on the web --></label>
         <name>labelVolunteerSignupThankYou</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelp --></label>
+        <name>labelVolunteersHelp</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpDescription --></label>
+        <name>labelVolunteersHelpDescription</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep1 --></label>
+        <name>labelVolunteersHelpStep1</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep1Text --></label>
+        <name>labelVolunteersHelpStep1Text</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep2 --></label>
+        <name>labelVolunteersHelpStep2</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep2Text --></label>
+        <name>labelVolunteersHelpStep2Text</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep3 --></label>
+        <name>labelVolunteersHelpStep3</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep3Text --></label>
+        <name>labelVolunteersHelpStep3Text</name>
     </customLabels>
     <customLabels>
         <label><!-- error string for signup of too many volunteers --></label>

--- a/src/translations/es.translation
+++ b/src/translations/es.translation
@@ -556,6 +556,22 @@ day: &apos;día&apos;</label>
         <name>labelTitleJobSignup</name>
     </customLabels>
     <customLabels>
+        <label><!-- labelVRSBatchDescription --></label>
+        <name>labelVRSBatchDescription</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVRSBatchProcess --></label>
+        <name>labelVRSBatchProcess</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVRSBatchProcessProgress --></label>
+        <name>labelVRSBatchProcessProgress</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVRSBatchRun --></label>
+        <name>labelVRSBatchRun</name>
+    </customLabels>
+    <customLabels>
         <label>Auto-Creado para Horario de Recurrencia de trabajo:</label>
         <name>labelVRSHoursCreatedSystemNote</name>
     </customLabels>
@@ -578,6 +594,38 @@ day: &apos;día&apos;</label>
     <customLabels>
         <label>Gracias por registrarse para el voluntariado.</label>
         <name>labelVolunteerSignupThankYou</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelp --></label>
+        <name>labelVolunteersHelp</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpDescription --></label>
+        <name>labelVolunteersHelpDescription</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep1 --></label>
+        <name>labelVolunteersHelpStep1</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep1Text --></label>
+        <name>labelVolunteersHelpStep1Text</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep2 --></label>
+        <name>labelVolunteersHelpStep2</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep2Text --></label>
+        <name>labelVolunteersHelpStep2Text</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep3 --></label>
+        <name>labelVolunteersHelpStep3</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep3Text --></label>
+        <name>labelVolunteersHelpStep3Text</name>
     </customLabels>
     <customLabels>
         <label>Se necesitan {0} voluntarios más para esta jornada.</label>

--- a/src/translations/fr.translation
+++ b/src/translations/fr.translation
@@ -556,6 +556,22 @@ day: &apos;jour&apos;</label>
         <name>labelTitleJobSignup</name>
     </customLabels>
     <customLabels>
+        <label><!-- labelVRSBatchDescription --></label>
+        <name>labelVRSBatchDescription</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVRSBatchProcess --></label>
+        <name>labelVRSBatchProcess</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVRSBatchProcessProgress --></label>
+        <name>labelVRSBatchProcessProgress</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVRSBatchRun --></label>
+        <name>labelVRSBatchRun</name>
+    </customLabels>
+    <customLabels>
         <label>Automatiquement Crée pour l&apos;Horaire de Récurrence des Bénévoles:</label>
         <name>labelVRSHoursCreatedSystemNote</name>
     </customLabels>
@@ -578,6 +594,38 @@ day: &apos;jour&apos;</label>
     <customLabels>
         <label>Merci de votre inscription pour le bénévolat.</label>
         <name>labelVolunteerSignupThankYou</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelp --></label>
+        <name>labelVolunteersHelp</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpDescription --></label>
+        <name>labelVolunteersHelpDescription</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep1 --></label>
+        <name>labelVolunteersHelpStep1</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep1Text --></label>
+        <name>labelVolunteersHelpStep1Text</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep2 --></label>
+        <name>labelVolunteersHelpStep2</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep2Text --></label>
+        <name>labelVolunteersHelpStep2Text</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep3 --></label>
+        <name>labelVolunteersHelpStep3</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep3Text --></label>
+        <name>labelVolunteersHelpStep3Text</name>
     </customLabels>
     <customLabels>
         <label>Il y a seulement {0} bénévoles toujours requis sur ce décalage.</label>

--- a/src/translations/ja.translation
+++ b/src/translations/ja.translation
@@ -556,6 +556,22 @@
         <name>labelTitleJobSignup</name>
     </customLabels>
     <customLabels>
+        <label><!-- labelVRSBatchDescription --></label>
+        <name>labelVRSBatchDescription</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVRSBatchProcess --></label>
+        <name>labelVRSBatchProcess</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVRSBatchProcessProgress --></label>
+        <name>labelVRSBatchProcessProgress</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVRSBatchRun --></label>
+        <name>labelVRSBatchRun</name>
+    </customLabels>
+    <customLabels>
         <label>定期的なボランティアスケジュールで自動作成されました:</label>
         <name>labelVRSHoursCreatedSystemNote</name>
     </customLabels>
@@ -578,6 +594,38 @@
     <customLabels>
         <label>ボランティアにサインアップしていただきありがとうございます。</label>
         <name>labelVolunteerSignupThankYou</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelp --></label>
+        <name>labelVolunteersHelp</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpDescription --></label>
+        <name>labelVolunteersHelpDescription</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep1 --></label>
+        <name>labelVolunteersHelpStep1</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep1Text --></label>
+        <name>labelVolunteersHelpStep1Text</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep2 --></label>
+        <name>labelVolunteersHelpStep2</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep2Text --></label>
+        <name>labelVolunteersHelpStep2Text</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep3 --></label>
+        <name>labelVolunteersHelpStep3</name>
+    </customLabels>
+    <customLabels>
+        <label><!-- labelVolunteersHelpStep3Text --></label>
+        <name>labelVolunteersHelpStep3Text</name>
     </customLabels>
     <customLabels>
         <label>このシフトで不足しているボランティアは {0} 人のみです。</label>


### PR DESCRIPTION
this pull request adds back references to already managed custom labels we were no longer using.  we have to keep them in the package because they can't be deleted.  I'm also using this pull request to include the release notes for recent work done to V4S that haven't yet been released but were not using our release note syntax.

# Critical Changes

# Changes
- A big Thank You to Stephen Judd and Vladimir Martinov for the following 4 community contributions!

- External Job Signups now supported. It is now possible to have an external signup site for a job, where the V4S app does not handle the registrations. When the user decides to sign up they are re-directed to the external site, where they process their registration. In order to set up this new functionality, the user has to enter the external site link in the “External Signup Url” field on the Volunteer Job object. The text of the external sign-up link can be customized with the custom label externalSignUpUrl. The link can be styled with the css class externalJobLink found in the VolunteerJobListingCSS file. The display of the external job listing detail can be styled with the css class externalJob found in the VolunteerJobListingCSS file.

- When clicking on a past shift from the Job Calendar, or when clicking on a link to a job with all shifts in the past, the user will still see the job details. The Sign-up link is replaced with text stating the job has no upcoming shifts. The text can be customized with the custom label labelEventInThePast. The detailed display of the past event can be customized with the css class pastEvent found in the VolunteerJobListingCSS file.

- The PersonalSiteReportHours page now supports filtering the list of Jobs to only those the volunteer has already signed up for. We can turn this functionality on and off by setting the Personal Site Report Hours Filtered custom setting. If the filtering is turned on and the Volunteer hadn’t signed up for any jobs, the user is informed by the text contained in the custom label labelPersonalSiteNoJobsforContact.

- Volunteers can now enter additional information along with the hours they worked on a particular job. That can be accomplished by adding fields to the VolunteersReportHoursFS fieldset on the Volunteer Hours object.

- German translations are now included in the package.

- Japanese translations are now included in the package.

# Issues Closed
Fixes #186 
Fixes #187 
Fixes #199 
Fixes #94 
Fixes #188 
Fixes #221

