### PR TITLE
optimize ProcessListVRS to reuse existing Hours if possible.  Issue #154

### DIFF
--- a/src/classes/VOL_BATCH_Recurrence_TEST.cls
+++ b/src/classes/VOL_BATCH_Recurrence_TEST.cls
@@ -58,16 +58,23 @@ public class VOL_BATCH_Recurrence_TEST {
 	}
 
 	@isTest private static void testSingleBatch() {
+	    
+	    // set future recurrence to low value for initial JRS insert
+	    VOL_SharedCode.VolunteersSettings.Recurring_Job_Future_Months__c = 1;
 		createRecurringJob();
+        List<Volunteer_Shift__c> shifts = [SELECT Id FROM Volunteer_Shift__c];
+        integer cShifts = shifts.size();
+        system.assert(cShifts >= 0 && cShifts <= 5);
+		
+        // now increase our future recurrence limit to a larger size and run the batch
+        VOL_SharedCode.VolunteersSettings.Recurring_Job_Future_Months__c = 2;
 		VOL_BATCH_Recurrence batchRecSched = new VOL_BATCH_Recurrence();
-
 		Test.startTest();
 		database.executeBatch(batchRecSched);
 		Test.stopTest();
-		Job_Recurrence_Schedule__c recurSched = [SELECT Id FROM Job_Recurrence_Schedule__c LIMIT 1];
-		List<Volunteer_Shift__c> shifts = [SELECT Id, Job_Recurrence_Schedule__c FROM Volunteer_Shift__c WHERE Job_Recurrence_Schedule__c = :recurSched.Id];
-
-		System.assertNotEquals(0, shifts.size(), 'Multiple shifts should have been created by the batch.');
+		shifts = [SELECT Id FROM Volunteer_Shift__c];
+		integer cShiftsNew = shifts.size() - cShifts;
+		system.assert(cShiftsNew >=3 && cShiftsNew <= 5);
 	}
 
 }

--- a/src/classes/VOL_JRS.cls
+++ b/src/classes/VOL_JRS.cls
@@ -132,17 +132,20 @@ public with sharing class VOL_JRS {
 			listVRS = [select Id, Name, Contact__c, Schedule_Start_Date_Time__c, Schedule_End_Date__c, Duration__c,
 				Weekly_Occurrence__c, Days_Of_Week__c, Volunteer_Job__c, Volunteer_Hours_Status__c, Number_of_Volunteers__c, Comments__c
 				from Volunteer_Recurrence_Schedule__c where Volunteer_Job__c in : setJobId];
-			VOL_VRS.ProcessListVRS(listVRS);
+			VOL_VRS.ProcessListVRS(listVRS, fReviewAllShifts);
 		} else {
-			ProcessListVRSFuture(setJobId);			
+			ProcessListVRSFuture(setJobId, fReviewAllShifts);			
 		}			
 	}
 	
     //******************************************************************************************************
 	// Process all the VRS's for the set of Job's.  This Future cover was created to avoid
 	// hitting apex system statement limits that we would hit if there were many VRS's for a given job.
+    // fReviewAllShifts parameter specifies whether called from the trigger on JRS's, in
+    // which case we should review all shifts under the Jobs, or from the scheduled batch,
+    // in which case we only need to be looking to add additional shifts in the future.
 	@future (callout=false)	
-	private static void ProcessListVRSFuture(set<ID> setJobId) {
+	private static void ProcessListVRSFuture(set<ID> setJobId, boolean fReviewAllShifts) {
 		
 		list<Volunteer_Recurrence_Schedule__c> listVRS = new list<Volunteer_Recurrence_Schedule__c>();
 		listVRS = [select Id, Name, Contact__c, Schedule_Start_Date_Time__c, Schedule_End_Date__c, Duration__c,
@@ -150,7 +153,7 @@ public with sharing class VOL_JRS {
 			from Volunteer_Recurrence_Schedule__c where Volunteer_Job__c in : setJobId];
 
 		// process the VRS's to create hours as needed.
-		VOL_VRS.ProcessListVRS(listVRS);
+		VOL_VRS.ProcessListVRS(listVRS, fReviewAllShifts);
 	}	
 	
 

--- a/src/classes/VOL_JRS.cls
+++ b/src/classes/VOL_JRS.cls
@@ -132,7 +132,7 @@ public with sharing class VOL_JRS {
 			listVRS = [select Id, Name, Contact__c, Schedule_Start_Date_Time__c, Schedule_End_Date__c, Duration__c,
 				Weekly_Occurrence__c, Days_Of_Week__c, Volunteer_Job__c, Volunteer_Hours_Status__c, Number_of_Volunteers__c, Comments__c
 				from Volunteer_Recurrence_Schedule__c where Volunteer_Job__c in : setJobId];
-			VOL_VRS.ProcessListVRS(listVRS, fReviewAllShifts);
+			VOL_VRS.ProcessListVRS(listVRS, null, fReviewAllShifts);
 		} else {
 			ProcessListVRSFuture(setJobId, fReviewAllShifts);			
 		}			
@@ -153,7 +153,7 @@ public with sharing class VOL_JRS {
 			from Volunteer_Recurrence_Schedule__c where Volunteer_Job__c in : setJobId];
 
 		// process the VRS's to create hours as needed.
-		VOL_VRS.ProcessListVRS(listVRS, fReviewAllShifts);
+		VOL_VRS.ProcessListVRS(listVRS, null, fReviewAllShifts);
 	}	
 	
 

--- a/src/classes/VOL_JRS_TEST.cls
+++ b/src/classes/VOL_JRS_TEST.cls
@@ -153,4 +153,99 @@ public with sharing class VOL_JRS_TEST {
 		
     }   
 
+    //******************************************************************************************************
+    // test that modifying a JRS reuses already existing Shifts    
+    public static testmethod void testJRSShiftReuse() {
+
+		// create test data
+        Campaign cmp = new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, 
+        	name='Job Calendar Test Campaign', IsActive=true);
+        insert cmp;
+        Volunteer_Job__c job = new Volunteer_Job__c(name='Job1', campaign__c=cmp.Id);
+        insert job;
+        Job_Recurrence_Schedule__c jrs = new Job_Recurrence_Schedule__c(Volunteer_Job__c = job.Id);
+		jrs.Days_of_Week__c = 'Monday';
+		jrs.Duration__c = 1;
+		jrs.Schedule_Start_Date_Time__c = system.now();
+		jrs.Weekly_Occurrence__c = 'Every';
+		jrs.Desired_Number_of_Volunteers__c = 5;
+        jrs.Description__c = 'initial description';
+		insert jrs;      
+        
+        list<Volunteer_Shift__c> listShift = [select Id from Volunteer_Shift__c];
+        set<ID> setShiftId = new set<ID>();
+        for (Volunteer_Shift__c shift : listShift)
+            setShiftId.add(shift.Id);
+        integer cShifts = setShiftId.size();
+        system.assert(cShifts > 0);
+        
+        // now modify the JRS
+        jrs.Days_of_Week__c = 'Monday;Tuesday';
+        jrs.Description__c = 'new description';
+        Test.startTest();
+        update jrs;
+        Test.stopTest();
+        
+        listShift = [select Id, CreatedDate, LastModifiedDate, Description__c from Volunteer_Shift__c];
+        integer cShiftsInitial = 0;
+        integer cShiftsNew = 0;
+        for (Volunteer_Shift__c shift : listShift) {
+            if (setShiftId.contains(shift.Id)) {
+                cShiftsInitial++;
+            } else {
+                cShiftsNew++;
+            }
+            system.assertEquals('new description', shift.Description__c);
+        }
+        system.assertEquals(cShifts, cShiftsInitial);
+        system.assert(cShifts == cShiftsNew || cShifts == cShiftsNew-1 || cShifts == cShiftsNew+1); 
+    }
+        
+    //******************************************************************************************************
+    // test that modifying a JRS deletes already existing Shifts that no longer match the JRS
+    public static testmethod void testJRSShiftDelete() {
+
+		// create test data
+        Campaign cmp = new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, 
+        	name='Job Calendar Test Campaign', IsActive=true);
+        insert cmp;
+        Volunteer_Job__c job = new Volunteer_Job__c(name='Job1', campaign__c=cmp.Id);
+        insert job;
+        Job_Recurrence_Schedule__c jrs = new Job_Recurrence_Schedule__c(Volunteer_Job__c = job.Id);
+		jrs.Days_of_Week__c = 'Monday';
+		jrs.Duration__c = 1;
+		jrs.Schedule_Start_Date_Time__c = system.now();
+		jrs.Weekly_Occurrence__c = 'Every';
+		jrs.Desired_Number_of_Volunteers__c = 5;
+        jrs.Description__c = 'initial description';
+		insert jrs;
+        
+        list<Volunteer_Shift__c> listShift = [select Id from Volunteer_Shift__c];
+        set<ID> setShiftId = new set<ID>();
+        for (Volunteer_Shift__c shift : listShift)
+            setShiftId.add(shift.Id);
+        integer cShifts = setShiftId.size();
+        system.assert(cShifts > 0);
+        
+        // now modify the JRS
+        jrs.Days_of_Week__c = 'Tuesday';
+        jrs.Description__c = 'new description';
+        Test.startTest();
+        update jrs;
+        Test.stopTest();
+        
+        listShift = [select Id, CreatedDate, LastModifiedDate, Description__c from Volunteer_Shift__c];
+        integer cShiftsInitial = 0;
+        integer cShiftsNew = 0;
+        for (Volunteer_Shift__c shift : listShift) {
+            if (setShiftId.contains(shift.Id)) {
+                cShiftsInitial++;
+            } else {
+                cShiftsNew++;
+            }
+            system.assertEquals('new description', shift.Description__c);
+        }
+        system.assertEquals(0, cShiftsInitial);
+        system.assert(cShifts == cShiftsNew || cShifts == cShiftsNew-1 || cShifts == cShiftsNew+1); 
+    }
 }

--- a/src/classes/VOL_VRS.cls
+++ b/src/classes/VOL_VRS.cls
@@ -80,7 +80,10 @@ public with sharing class VOL_VRS {
 	// no longer match, and creates new hours into the future.
 	// called from both the VRS trigger (when the user modifies a specific VRS),
 	// as well as from the JRS processing, so new shifts get their hours assigned.
-	public static void ProcessListVRS(list<Volunteer_Recurrence_Schedule__c> listVRS) {
+    // fReviewAllShifts parameter specifies whether called from the trigger on JRS's, in
+    // which case we should review all shifts under the Jobs, or from the scheduled batch,
+    // in which case we only need to be looking to add additional shifts in the future.
+	public static void ProcessListVRS(list<Volunteer_Recurrence_Schedule__c> listVRS, boolean fReviewAllShifts) {
 		
 		// get a set of the VRS ID's for querying
 		// also the Job ID's they are associated with
@@ -96,10 +99,16 @@ public with sharing class VOL_VRS {
 							
 		// get all shifts of the jobs these vrs's are associated with
 		list<Volunteer_Shift__c> listShift = new list<Volunteer_Shift__c>();
-		listShift = [select Id, Duration__c, Start_Date_Time__c, Desired_Number_of_Volunteers__c, 
-			Volunteer_Job__c from Volunteer_Shift__c
-			where Volunteer_Job__c in :setJobId];
-			
+		if (fReviewAllShifts) {
+			listShift = [select Id, Duration__c, Start_Date_Time__c, Desired_Number_of_Volunteers__c, 
+				Volunteer_Job__c from Volunteer_Shift__c
+				where Volunteer_Job__c in :setJobId];
+		} else {
+            listShift = [select Id, Duration__c, Start_Date_Time__c, Desired_Number_of_Volunteers__c, 
+                Volunteer_Job__c from Volunteer_Shift__c
+                where Volunteer_Job__c in :setJobId and Start_Date_Time__c >= TODAY];
+		}
+		
 		// construct a map of Job to its associated list of VRS's
 		map<ID, list<Volunteer_Recurrence_Schedule__c>> mapJobIdListVRS = new map<ID, list<Volunteer_Recurrence_Schedule__c>>();
 		
@@ -114,9 +123,16 @@ public with sharing class VOL_VRS {
 		// in order to avoid creating hours that already exist (completed or canceled),
 		// create a set of shiftId|contactId tuples, which allows us to quickly see if we
 		// already have an hours record for the given shift and contact.
-		list<Volunteer_Hours__c> listHoursExisting = [select Id, Volunteer_Job__c, Volunteer_Recurrence_Schedule__c,
-			Volunteer_Shift__c, Status__c, Contact__c from
-			Volunteer_Hours__c where Volunteer_Job__c in :setJobId and Contact__c in :setContactId];
+		list<Volunteer_Hours__c> listHoursExisting = new list<Volunteer_Hours__c>();
+		if (fReviewAllShifts) { 
+			listHoursExisting = [select Id, Volunteer_Job__c, Volunteer_Recurrence_Schedule__c,
+				Volunteer_Shift__c, Status__c, Contact__c from
+				Volunteer_Hours__c where Volunteer_Job__c in :setJobId and Contact__c in :setContactId];
+		} else {
+            listHoursExisting = [select Id, Volunteer_Job__c, Volunteer_Recurrence_Schedule__c,
+                Volunteer_Shift__c, Status__c, Contact__c from
+                Volunteer_Hours__c where Volunteer_Job__c in :setJobId and Contact__c in :setContactId and Shift_Start_Date_Time__c >= TODAY];
+		}
 		map<string, Volunteer_Hours__c> mapShiftIdContactIdToHours = new map<string, Volunteer_Hours__c>();
 		for (Volunteer_Hours__c hr : listHoursExisting) {
 			mapShiftIdContactIdToHours.put(hr.Volunteer_Shift__c + '|' + hr.Contact__c, hr);
@@ -124,13 +140,19 @@ public with sharing class VOL_VRS {
 
 		// create hours for these vrs's for each shift 				
 		list<Volunteer_Hours__c> listHoursNew = new list<Volunteer_Hours__c>();
+        list<Volunteer_Hours__c> listHoursUpdate = new list<Volunteer_Hours__c>();
 		for (Volunteer_Shift__c shift : listShift) {
 			list<Volunteer_Recurrence_Schedule__c> listVRSforJob = mapJobIdListVRS.get(shift.Volunteer_Job__c);
-			AssignVRSHours(shift, listVRSforJob, mapShiftIdContactIdToHours, listHoursNew);
+			AssignVRSHours(shift, listVRSforJob, mapShiftIdContactIdToHours, listHoursNew, listHoursUpdate);
 		}
-		if (listHoursNew.size() > 0)
+		if (listHoursNew.size() > 0) {
 			insert listHoursNew;
+		}
 			
+        if (listHoursUpdate.size() > 0) {
+            update listHoursUpdate;
+        }
+
 		// mapShiftIdContactIdToHours now contains only the Hours that did not match the VRS's, 
 		// so we can delete them if they aren't marked Completed or Canceled.
 		list<Volunteer_Hours__c> listHRDelete = new list<Volunteer_Hours__c>();
@@ -139,8 +161,10 @@ public with sharing class VOL_VRS {
 		        listHRDelete.add(hr);
 		    }
 		}
-        if (listHRDelete.size() > 0)
+        if (listHRDelete.size() > 0) {
+            system.debug('****DJH: deleting listHRDelete: ' + listHRDelete);
             delete listHRDelete;
+        }
 	}
 	
     //******************************************************************************************************
@@ -152,11 +176,13 @@ public with sharing class VOL_VRS {
 	// matched, they are removed from this map.  So upon return, this map contains those Hours that no longer
 	// match their VRS (so they can be considered for deletion).
 	// @param listHoursNew The returned set of Hours to create (leaving creation to the caller)
+    // @param listHoursUpdate The returned set of Hours to update (leaving update to the caller)
 	private static void AssignVRSHours(
 		Volunteer_Shift__c shift, 
 		list<Volunteer_Recurrence_Schedule__c> listVRS, 
 		map<string, Volunteer_Hours__c> mapShiftIdContactIdToHours,
-		list<Volunteer_Hours__c> listHoursNew
+		list<Volunteer_Hours__c> listHoursNew,
+        list<Volunteer_Hours__c> listHoursUpdate
 		) {
 			
 		if (listVRS == null) return; 
@@ -187,7 +213,7 @@ public with sharing class VOL_VRS {
 			
 			if (vrs.Weekly_Occurrence__c == null)
 				continue;
-			
+				
 			if ((listWhichWeeks[nweek] || 
 					vrs.Weekly_Occurrence__c.contains('Every') ||
 					(vrs.Weekly_Occurrence__c.contains('Alternate') && alternateWeekVRS(vrs, dtShift))) && 
@@ -195,13 +221,27 @@ public with sharing class VOL_VRS {
 				vrs.Schedule_Start_Date_Time__c != null &&
 				dtShift >= vrs.Schedule_Start_Date_Time__c.Date() &&
 				(vrs.Schedule_End_Date__c == null || vrs.Schedule_End_Date__c >= dtShift)) {
-					
+				    
 				// we need to deal with the person already having hours on this shift
 				// that might be completed, or canceled, or web signup.  
 				// avoid creating another confirmed record.
 				// note that if we match, we remove the key from the map, so we know it was matched.
-				if (mapShiftIdContactIdToHours.containsKey(shift.Id + '|' + vrs.Contact__c)) {
-					mapShiftIdContactIdToHours.remove(shift.Id + '|' + vrs.Contact__c);
+				Volunteer_Hours__c hrExisting = mapShiftIdContactIdToHours.get(shift.Id + '|' + vrs.Contact__c);
+				if (hrExisting != null) {
+					// if shift/hour in the future, we update a subset of fields
+					if (dtShift >= System.today()) {
+                        hrExisting.Hours_Worked__c = vrs.Duration__c;
+                        if (vrs.Number_of_Volunteers__c != null && vrs.Number_of_Volunteers__c >= 1)
+                            hrExisting.Number_of_Volunteers__c = vrs.Number_of_Volunteers__c;
+                        if (vrs.Volunteer_Hours_Status__c != null) 
+                            hrExisting.Status__c = vrs.Volunteer_Hours_Status__c;
+                        hrExisting.Planned_Start_Date_Time__c = datetime.newInstance(shift.Start_Date_Time__c.date(), vrs.Schedule_Start_Date_Time__c.time());
+                        if (vrs.Comments__c != null)
+                            hrExisting.Comments__c = vrs.Comments__c;
+                        listHoursUpdate.add(hrExisting);
+					}
+                    // remove it from the map so we know it was matched
+                    mapShiftIdContactIdToHours.remove(shift.Id + '|' + vrs.Contact__c);                    
 					continue;
 				}
 									
@@ -229,7 +269,7 @@ public with sharing class VOL_VRS {
 				hr.Comments__c = vrs.Comments__c;
 				listHoursNew.add(hr);
 				//cDesiredVols--;
-			}			 		
+			} 			 		
 		}
 		
 		// we let the caller commit the new hours to the db.		

--- a/src/classes/VOL_VRS.cls
+++ b/src/classes/VOL_VRS.cls
@@ -80,10 +80,15 @@ public with sharing class VOL_VRS {
 	// no longer match, and creates new hours into the future.
 	// called from both the VRS trigger (when the user modifies a specific VRS),
 	// as well as from the JRS processing, so new shifts get their hours assigned.
-    // fReviewAllShifts parameter specifies whether called from the trigger on JRS's, in
+	// @param listVRS the list of VRS's to process
+	// @param listVRSOld If called from the AfterUpdate trigger, the trigger.old list
+	// @param fReviewAllShifts Specifies whether called from the trigger on JRS's, in
     // which case we should review all shifts under the Jobs, or from the scheduled batch,
     // in which case we only need to be looking to add additional shifts in the future.
-	public static void ProcessListVRS(list<Volunteer_Recurrence_Schedule__c> listVRS, boolean fReviewAllShifts) {
+	public static void ProcessListVRS(
+	   list<Volunteer_Recurrence_Schedule__c> listVRS, 
+	   list<Volunteer_Recurrence_Schedule__c> listVRSOld, 
+	   boolean fReviewAllShifts) {
 		
 		// get a set of the VRS ID's for querying
 		// also the Job ID's they are associated with
@@ -95,6 +100,15 @@ public with sharing class VOL_VRS {
 			setVRSId.add(vrs.Id);
 			setJobId.add(vrs.Volunteer_Job__c);
 			setContactId.add(vrs.Contact__c);
+		}
+		
+		// if the VRS was updated, then deal with potent changes to the VRS's job or contact 
+		if (listVRSOld != null) {
+	        for (Volunteer_Recurrence_Schedule__c vrs : listVRSOld) {
+	            setVRSId.add(vrs.Id);
+	            setJobId.add(vrs.Volunteer_Job__c);
+	            setContactId.add(vrs.Contact__c);
+	        }
 		}
 							
 		// get all shifts of the jobs these vrs's are associated with

--- a/src/classes/VOL_VRS.cls
+++ b/src/classes/VOL_VRS.cls
@@ -36,262 +36,262 @@ public with sharing class VOL_VRS {
 
 
     //******************************************************************************************************
-    // for the specified VRS's, delete all hours that are not completed hours.
-    // called from the After Delete VRS trigger.
-    public static void DeleteListVRS(list<Volunteer_Recurrence_Schedule__c> listVRS) {
-        DeleteListVRS(listVRS, false);
-    }
-        
+	// for the specified VRS's, delete all hours that are not completed hours.
+	// called from the After Delete VRS trigger.
+	public static void DeleteListVRS(list<Volunteer_Recurrence_Schedule__c> listVRS) {
+		DeleteListVRS(listVRS, false);
+	}
+		
     //******************************************************************************************************
-    // for the specified VRS's, delete all hours that are not completed hours.
-    // called from the After Delete VRS trigger and when we are processing a modified VRS.
-    private static void DeleteListVRS(list<Volunteer_Recurrence_Schedule__c> listVRS, boolean fPreserveCanceled) {
+	// for the specified VRS's, delete all hours that are not completed hours.
+	// called from the After Delete VRS trigger and when we are processing a modified VRS.
+	private static void DeleteListVRS(list<Volunteer_Recurrence_Schedule__c> listVRS, boolean fPreserveCanceled) {
 
-        // get a set of the VRS ID's for querying
-        set<ID> setVRSId = new set<ID>();
-        for (Volunteer_Recurrence_Schedule__c vrs : listVRS) {
-            setVRSId.add(vrs.Id);
-        }
-        
-        // get all hours associated with these VRS's that we should delete
-        list<Volunteer_Hours__c> listHours = new list<Volunteer_Hours__c>();
-        if (fPreserveCanceled) {
-            listHours = [select Id from Volunteer_Hours__c  
-                where (Status__c <> 'Completed' and Status__c <> 'Canceled' and
-                    Volunteer_Recurrence_Schedule__c in : setVRSId)];
-        } else {
-            listHours = [select Id from Volunteer_Hours__c  
-                where (Status__c <> 'Completed' and
-                    Volunteer_Recurrence_Schedule__c in : setVRSId)];           
-        }
-                
-        if (listHours.size() > 0) {
-            delete listHours;
-            
-            // if PreserveCanceled, then we know we are updating the VRS, and so there is no need
-            // to keep the deleted Hours in the recycle bin, since we are going to recreate the hours.
-            if (fPreserveCanceled)
-                Database.emptyRecycleBin(listHours);
-        }
-    }
+		// get a set of the VRS ID's for querying
+		set<ID> setVRSId = new set<ID>();
+		for (Volunteer_Recurrence_Schedule__c vrs : listVRS) {
+			setVRSId.add(vrs.Id);
+		}
+		
+		// get all hours associated with these VRS's that we should delete
+		list<Volunteer_Hours__c> listHours = new list<Volunteer_Hours__c>();
+		if (fPreserveCanceled) {
+			listHours = [select Id from Volunteer_Hours__c  
+				where (Status__c <> 'Completed' and Status__c <> 'Canceled' and
+					Volunteer_Recurrence_Schedule__c in : setVRSId)];
+		} else {
+			listHours = [select Id from Volunteer_Hours__c  
+				where (Status__c <> 'Completed' and
+					Volunteer_Recurrence_Schedule__c in : setVRSId)];			
+		}
+				
+		if (listHours.size() > 0) {
+			delete listHours;
+			
+			// if PreserveCanceled, then we know we are updating the VRS, and so there is no need
+			// to keep the deleted Hours in the recycle bin, since we are going to recreate the hours.
+			if (fPreserveCanceled)
+				Database.emptyRecycleBin(listHours);
+		}
+	}
 
-    //******************************************************************************************************
-    // given a list of Volunteer recurring schedules, does all the work to delete any hours that
-    // no longer match, and creates new hours into the future.
-    // called from both the VRS trigger (when the user modifies a specific VRS),
-    // as well as from the JRS processing, so new shifts get their hours assigned.
-    public static void ProcessListVRS(list<Volunteer_Recurrence_Schedule__c> listVRS) {
-        
-        // get a set of the VRS ID's for querying
-        // also the Job ID's they are associated with
-        // also the contact ID's they are associated with
-        set<ID> setVRSId = new set<ID>();
-        set<ID> setJobId = new set<ID>();
-        set<ID> setContactId = new set<ID>();
-        for (Volunteer_Recurrence_Schedule__c vrs : listVRS) {
-            setVRSId.add(vrs.Id);
-            setJobId.add(vrs.Volunteer_Job__c);
-            setContactId.add(vrs.Contact__c);
-        }
-                            
-        // get all shifts of the jobs these vrs's are associated with
-        list<Volunteer_Shift__c> listShift = new list<Volunteer_Shift__c>();
-        listShift = [select Id, Duration__c, Start_Date_Time__c, Desired_Number_of_Volunteers__c, 
-            Volunteer_Job__c from Volunteer_Shift__c
-            where Volunteer_Job__c in :setJobId];
-            
-        // construct a map of Job to its associated list of VRS's
-        map<ID, list<Volunteer_Recurrence_Schedule__c>> mapJobIdListVRS = new map<ID, list<Volunteer_Recurrence_Schedule__c>>();
-        
-        // put the VRS's on each job's list
-        for (Volunteer_Recurrence_Schedule__c vrs : listVRS) {          
-            list<Volunteer_Recurrence_Schedule__c> listVRSforJob = mapJobIdListVRS.get(vrs.Volunteer_Job__c);
-            if (listVRSforJob == null) listVRSforJob = new list<Volunteer_Recurrence_Schedule__c>();
-            listVRSforJob.add(vrs);
-            mapJobIdListVRS.put(vrs.Volunteer_Job__c, listVRSforJob);               
-        }
-    
-        // in order to avoid creating hours that already exist (completed or canceled),
-        // create a set of shiftId|contactId tuples, which allows us to quickly see if we
-        // already have an hours record for the given shift and contact.
-        list<Volunteer_Hours__c> listHoursExisting = [select Id, Volunteer_Job__c, Volunteer_Recurrence_Schedule__c,
-            Volunteer_Shift__c, Status__c, Contact__c from
-            Volunteer_Hours__c where Volunteer_Job__c in :setJobId and Contact__c in :setContactId];
-        map<string, Volunteer_Hours__c> mapShiftIdContactIdToHours = new map<string, Volunteer_Hours__c>();
-        for (Volunteer_Hours__c hr : listHoursExisting) {
-            mapShiftIdContactIdToHours.put(hr.Volunteer_Shift__c + '|' + hr.Contact__c, hr);
-        }
+   	//******************************************************************************************************
+	// given a list of Volunteer recurring schedules, does all the work to delete any hours that
+	// no longer match, and creates new hours into the future.
+	// called from both the VRS trigger (when the user modifies a specific VRS),
+	// as well as from the JRS processing, so new shifts get their hours assigned.
+	public static void ProcessListVRS(list<Volunteer_Recurrence_Schedule__c> listVRS) {
+		
+		// get a set of the VRS ID's for querying
+		// also the Job ID's they are associated with
+		// also the contact ID's they are associated with
+		set<ID> setVRSId = new set<ID>();
+		set<ID> setJobId = new set<ID>();
+		set<ID> setContactId = new set<ID>();
+		for (Volunteer_Recurrence_Schedule__c vrs : listVRS) {
+			setVRSId.add(vrs.Id);
+			setJobId.add(vrs.Volunteer_Job__c);
+			setContactId.add(vrs.Contact__c);
+		}
+							
+		// get all shifts of the jobs these vrs's are associated with
+		list<Volunteer_Shift__c> listShift = new list<Volunteer_Shift__c>();
+		listShift = [select Id, Duration__c, Start_Date_Time__c, Desired_Number_of_Volunteers__c, 
+			Volunteer_Job__c from Volunteer_Shift__c
+			where Volunteer_Job__c in :setJobId];
+			
+		// construct a map of Job to its associated list of VRS's
+		map<ID, list<Volunteer_Recurrence_Schedule__c>> mapJobIdListVRS = new map<ID, list<Volunteer_Recurrence_Schedule__c>>();
+		
+		// put the VRS's on each job's list
+		for (Volunteer_Recurrence_Schedule__c vrs : listVRS) {			
+			list<Volunteer_Recurrence_Schedule__c> listVRSforJob = mapJobIdListVRS.get(vrs.Volunteer_Job__c);
+			if (listVRSforJob == null) listVRSforJob = new list<Volunteer_Recurrence_Schedule__c>();
+			listVRSforJob.add(vrs);
+			mapJobIdListVRS.put(vrs.Volunteer_Job__c, listVRSforJob);				
+		}
+	
+		// in order to avoid creating hours that already exist (completed or canceled),
+		// create a set of shiftId|contactId tuples, which allows us to quickly see if we
+		// already have an hours record for the given shift and contact.
+		list<Volunteer_Hours__c> listHoursExisting = [select Id, Volunteer_Job__c, Volunteer_Recurrence_Schedule__c,
+			Volunteer_Shift__c, Status__c, Contact__c from
+			Volunteer_Hours__c where Volunteer_Job__c in :setJobId and Contact__c in :setContactId];
+		map<string, Volunteer_Hours__c> mapShiftIdContactIdToHours = new map<string, Volunteer_Hours__c>();
+		for (Volunteer_Hours__c hr : listHoursExisting) {
+			mapShiftIdContactIdToHours.put(hr.Volunteer_Shift__c + '|' + hr.Contact__c, hr);
+		}
 
-        // create hours for these vrs's for each shift              
-        list<Volunteer_Hours__c> listHoursNew = new list<Volunteer_Hours__c>();
-        for (Volunteer_Shift__c shift : listShift) {
-            list<Volunteer_Recurrence_Schedule__c> listVRSforJob = mapJobIdListVRS.get(shift.Volunteer_Job__c);
-            AssignVRSHours(shift, listVRSforJob, mapShiftIdContactIdToHours, listHoursNew);
-        }
-        if (listHoursNew.size() > 0)
-            insert listHoursNew;
-            
-        // mapShiftIdContactIdToHours now contains only the Hours that did not match the VRS's, 
-        // so we can delete them if they aren't marked Completed or Canceled.
-        list<Volunteer_Hours__c> listHRDelete = new list<Volunteer_Hours__c>();
-        for (Volunteer_Hours__c hr : mapShiftIdContactIdToHours.values()) {
-            if (hr.Status__c != 'Completed' && hr.Status__c != 'Canceled') {
-                listHRDelete.add(hr);
-            }
-        }
+		// create hours for these vrs's for each shift 				
+		list<Volunteer_Hours__c> listHoursNew = new list<Volunteer_Hours__c>();
+		for (Volunteer_Shift__c shift : listShift) {
+			list<Volunteer_Recurrence_Schedule__c> listVRSforJob = mapJobIdListVRS.get(shift.Volunteer_Job__c);
+			AssignVRSHours(shift, listVRSforJob, mapShiftIdContactIdToHours, listHoursNew);
+		}
+		if (listHoursNew.size() > 0)
+			insert listHoursNew;
+			
+		// mapShiftIdContactIdToHours now contains only the Hours that did not match the VRS's, 
+		// so we can delete them if they aren't marked Completed or Canceled.
+		list<Volunteer_Hours__c> listHRDelete = new list<Volunteer_Hours__c>();
+		for (Volunteer_Hours__c hr : mapShiftIdContactIdToHours.values()) {
+		    if (hr.Status__c != 'Completed' && hr.Status__c != 'Canceled') {
+		        listHRDelete.add(hr);
+		    }
+		}
         if (listHRDelete.size() > 0)
             delete listHRDelete;
-    }
-    
+	}
+	
     //******************************************************************************************************
-    // @description for the specified shift, create VolunteerHours records for all volunteers
-    // who have a recurring schedule which should include this shift.
-    // @param shift The shift to assign Hours to
-    // @param listVRS The list of VRS's to consider for assigning hours to the shift
-    // @param mapShiftIdContactIdToHours A map of shiftId/ContactId keys to existing Hours.  As Hours are
-    // matched, they are removed from this map.  So upon return, this map contains those Hours that no longer
-    // match their VRS (so they can be considered for deletion).
-    // @param listHoursNew The returned set of Hours to create (leaving creation to the caller)
-    private static void AssignVRSHours(
-        Volunteer_Shift__c shift, 
-        list<Volunteer_Recurrence_Schedule__c> listVRS, 
-        map<string, Volunteer_Hours__c> mapShiftIdContactIdToHours,
-        list<Volunteer_Hours__c> listHoursNew
-        ) {
-            
-        if (listVRS == null) return; 
+	// @description for the specified shift, create VolunteerHours records for all volunteers
+	// who have a recurring schedule which should include this shift.
+	// @param shift The shift to assign Hours to
+	// @param listVRS The list of VRS's to consider for assigning hours to the shift
+	// @param mapShiftIdContactIdToHours A map of shiftId/ContactId keys to existing Hours.  As Hours are
+	// matched, they are removed from this map.  So upon return, this map contains those Hours that no longer
+	// match their VRS (so they can be considered for deletion).
+	// @param listHoursNew The returned set of Hours to create (leaving creation to the caller)
+	private static void AssignVRSHours(
+		Volunteer_Shift__c shift, 
+		list<Volunteer_Recurrence_Schedule__c> listVRS, 
+		map<string, Volunteer_Hours__c> mapShiftIdContactIdToHours,
+		list<Volunteer_Hours__c> listHoursNew
+		) {
+			
+		if (listVRS == null) return; 
 
-        // Strategy:
-        // for the given shift, go through the list of VRS's
-        // and create hours for the ones that match.
-        
-        // we decided not to limit the number of volunteers assigned
-        //integer cDesiredVols = 1000;
-        //if (shift.Desired_Number_of_Volunteers__c != null) 
-        //  cDesiredVols = integer.valueOf(shift.Desired_Number_of_Volunteers__c);
-        Date dtShift = shift.Start_Date_Time__c.Date();
-        DateTime dtShiftEnd = shift.Start_Date_Time__c.addMinutes(integer.valueOf(shift.Duration__c * 60));
-        integer nday = VOL_JRS.nDayOfWeek(dtShift);
-        
-        for (Volunteer_Recurrence_Schedule__c vrs : listVRS) {
-        
-            // exit if we've filled all the slots.
-            //if (cDesiredVols <= 0) 
-                //break;
-    
-            // for this jrs, what week should we treat this shift as
-            integer nweek = VOL_JRS.nWeekOfDate(dtFirstOccurrenceInWeek(vrs, dtShift));
-        
-            list<boolean> listWhichDays = WhichDaysVRS(vrs);
-            list<boolean> listWhichWeeks = WhichWeeksVRS(vrs);
-            
-            if (vrs.Weekly_Occurrence__c == null)
-                continue;
-            
-            if ((listWhichWeeks[nweek] || 
-                    vrs.Weekly_Occurrence__c.contains('Every') ||
-                    (vrs.Weekly_Occurrence__c.contains('Alternate') && alternateWeekVRS(vrs, dtShift))) && 
-                listWhichDays[nday] &&
-                vrs.Schedule_Start_Date_Time__c != null &&
-                dtShift >= vrs.Schedule_Start_Date_Time__c.Date() &&
-                (vrs.Schedule_End_Date__c == null || vrs.Schedule_End_Date__c >= dtShift)) {
-                    
-                // we need to deal with the person already having hours on this shift
-                // that might be completed, or canceled, or web signup.  
-                // avoid creating another confirmed record.
-                // note that if we match, we remove the key from the map, so we know it was matched.
-                if (mapShiftIdContactIdToHours.containsKey(shift.Id + '|' + vrs.Contact__c)) {
-                    mapShiftIdContactIdToHours.remove(shift.Id + '|' + vrs.Contact__c);
-                    continue;
-                }
-                                    
-                // only take volunteers whose time fits in the shift time (to handle multiple shifts per day)
-                Time tmVRS = vrs.Schedule_Start_Date_Time__c.Time();                
-                DateTime dtVRSStart =  datetime.newInstance(dtShift, tmVRS);
-                if (dtVRSStart < shift.Start_Date_Time__c  || dtVRSStart >= dtShiftEnd) {
-                    continue;                   
-                }   
-                    
-                Volunteer_Hours__c hr = new Volunteer_Hours__c();
-                hr.System_Note__c = label.labelVRSHoursCreatedSystemNote + ' ' + vrs.Name + '.';
-                hr.Contact__c = vrs.Contact__c;
-                hr.Hours_Worked__c = vrs.Duration__c;
-                hr.Number_of_Volunteers__c = 1;
-                if (vrs.Number_of_Volunteers__c != null && vrs.Number_of_Volunteers__c > 1)
-                    hr.Number_of_Volunteers__c = vrs.Number_of_Volunteers__c; 
-                hr.Start_Date__c = dtShift;
-                hr.End_Date__c = dtShift;
-                hr.Status__c = (vrs.Volunteer_Hours_Status__c == null ? 'Confirmed' : vrs.Volunteer_Hours_Status__c);
-                hr.Volunteer_Job__c = shift.Volunteer_Job__c;
-                hr.Volunteer_Shift__c = shift.Id;   
-                hr.Volunteer_Recurrence_Schedule__c = vrs.Id;   
-                hr.Planned_Start_Date_Time__c = datetime.newInstance(shift.Start_Date_Time__c.date(), vrs.Schedule_Start_Date_Time__c.time());
-                hr.Comments__c = vrs.Comments__c;
-                listHoursNew.add(hr);
-                //cDesiredVols--;
-            }                   
-        }
-        
-        // we let the caller commit the new hours to the db.        
-    }
-
-    //******************************************************************************************************
-    // returns whether the nweek of the specified date is an alternate week for this schedule
-    public static boolean alternateWeekVRS(Volunteer_Recurrence_Schedule__c vrs, Date dt) {
-        if (vrs.Schedule_Start_Date_Time__c == null) return false;
-        Date dtStart = vrs.Schedule_Start_Date_Time__c.Date().toStartOfWeek();
-        Date dtEnd = dt.toStartOfWeek();
-        integer cdays = dtStart.daysBetween(dtEnd);
-        integer nweeks = (cdays + 1) / 7;
-        return math.mod(nweeks, 2) == 0 ? true : false;     
-    }       
-        
-    //******************************************************************************************************
-    // returns an array of booleans for which days are on the schedule.
-    // note that you should index by nDay (ie, Mon = index 2).
-    private static list<boolean> WhichDaysVRS (Volunteer_Recurrence_Schedule__c vrs) {
-        list<boolean> listWhichDays = new boolean[] { false, false, false, false, false, false, false, false };
-        boolean isSun = VOL_JRS.isSundayFirstOfWeek();
-        
-        if (vrs.Days_of_Week__c != null) {
-            listWhichDays[isSun ? 1 : 7] = vrs.Days_of_Week__c.contains('Sunday');
-            listWhichDays[isSun ? 2 : 1] = vrs.Days_of_Week__c.contains('Monday');
-            listWhichDays[isSun ? 3 : 2] = vrs.Days_of_Week__c.contains('Tuesday');
-            listWhichDays[isSun ? 4 : 3] = vrs.Days_of_Week__c.contains('Wednesday');
-            listWhichDays[isSun ? 5 : 4] = vrs.Days_of_Week__c.contains('Thursday');
-            listWhichDays[isSun ? 6 : 5] = vrs.Days_of_Week__c.contains('Friday');
-            listWhichDays[isSun ? 7 : 6] = vrs.Days_of_Week__c.contains('Saturday');
-        }
-        return listWhichDays; 
-    }
+		// Strategy:
+		// for the given shift, go through the list of VRS's
+		// and create hours for the ones that match.
+		
+		// we decided not to limit the number of volunteers assigned
+		//integer cDesiredVols = 1000;
+		//if (shift.Desired_Number_of_Volunteers__c != null) 
+		//	cDesiredVols = integer.valueOf(shift.Desired_Number_of_Volunteers__c);
+		Date dtShift = shift.Start_Date_Time__c.Date();
+		DateTime dtShiftEnd = shift.Start_Date_Time__c.addMinutes(integer.valueOf(shift.Duration__c * 60));
+		integer nday = VOL_JRS.nDayOfWeek(dtShift);
+		
+		for (Volunteer_Recurrence_Schedule__c vrs : listVRS) {
+		
+			// exit if we've filled all the slots.
+			//if (cDesiredVols <= 0) 
+				//break;
+	
+			// for this jrs, what week should we treat this shift as
+			integer nweek = VOL_JRS.nWeekOfDate(dtFirstOccurrenceInWeek(vrs, dtShift));
+		
+			list<boolean> listWhichDays = WhichDaysVRS(vrs);
+			list<boolean> listWhichWeeks = WhichWeeksVRS(vrs);
+			
+			if (vrs.Weekly_Occurrence__c == null)
+				continue;
+			
+			if ((listWhichWeeks[nweek] || 
+					vrs.Weekly_Occurrence__c.contains('Every') ||
+					(vrs.Weekly_Occurrence__c.contains('Alternate') && alternateWeekVRS(vrs, dtShift))) && 
+				listWhichDays[nday] &&
+				vrs.Schedule_Start_Date_Time__c != null &&
+				dtShift >= vrs.Schedule_Start_Date_Time__c.Date() &&
+				(vrs.Schedule_End_Date__c == null || vrs.Schedule_End_Date__c >= dtShift)) {
+					
+				// we need to deal with the person already having hours on this shift
+				// that might be completed, or canceled, or web signup.  
+				// avoid creating another confirmed record.
+				// note that if we match, we remove the key from the map, so we know it was matched.
+				if (mapShiftIdContactIdToHours.containsKey(shift.Id + '|' + vrs.Contact__c)) {
+					mapShiftIdContactIdToHours.remove(shift.Id + '|' + vrs.Contact__c);
+					continue;
+				}
+									
+				// only take volunteers whose time fits in the shift time (to handle multiple shifts per day)
+				Time tmVRS = vrs.Schedule_Start_Date_Time__c.Time();				
+				DateTime dtVRSStart =  datetime.newInstance(dtShift, tmVRS);
+				if (dtVRSStart < shift.Start_Date_Time__c  || dtVRSStart >= dtShiftEnd) {
+					continue;					
+				}	
+					
+				Volunteer_Hours__c hr = new Volunteer_Hours__c();
+				hr.System_Note__c = label.labelVRSHoursCreatedSystemNote + ' ' + vrs.Name + '.';
+				hr.Contact__c = vrs.Contact__c;
+				hr.Hours_Worked__c = vrs.Duration__c;
+				hr.Number_of_Volunteers__c = 1;
+				if (vrs.Number_of_Volunteers__c != null && vrs.Number_of_Volunteers__c > 1)
+					hr.Number_of_Volunteers__c = vrs.Number_of_Volunteers__c; 
+				hr.Start_Date__c = dtShift;
+				hr.End_Date__c = dtShift;
+				hr.Status__c = (vrs.Volunteer_Hours_Status__c == null ? 'Confirmed' : vrs.Volunteer_Hours_Status__c);
+				hr.Volunteer_Job__c = shift.Volunteer_Job__c;
+				hr.Volunteer_Shift__c = shift.Id;	
+				hr.Volunteer_Recurrence_Schedule__c = vrs.Id;	
+				hr.Planned_Start_Date_Time__c = datetime.newInstance(shift.Start_Date_Time__c.date(), vrs.Schedule_Start_Date_Time__c.time());
+				hr.Comments__c = vrs.Comments__c;
+				listHoursNew.add(hr);
+				//cDesiredVols--;
+			}			 		
+		}
+		
+		// we let the caller commit the new hours to the db.		
+	}
 
     //******************************************************************************************************
-    // returns an array of booleans for which weeks are on the schedule.
-    // note that you should index by nWeek (ie, first = index 1).
-    private static list<boolean> WhichWeeksVRS(Volunteer_Recurrence_Schedule__c vrs) {
-        list<boolean> listWhichWeeks = new boolean[] { false, false, false, false, false, false };
-        if (vrs.Weekly_Occurrence__c != null) {
-            listWhichWeeks[1] = vrs.Weekly_Occurrence__c.contains('1st');
-            listWhichWeeks[2] = vrs.Weekly_Occurrence__c.contains('2nd');
-            listWhichWeeks[3] = vrs.Weekly_Occurrence__c.contains('3rd');
-            listWhichWeeks[4] = vrs.Weekly_Occurrence__c.contains('4th');
-            listWhichWeeks[5] = vrs.Weekly_Occurrence__c.contains('5th');
-        }
-        return listWhichWeeks;
-    }
+	// returns whether the nweek of the specified date is an alternate week for this schedule
+	public static boolean alternateWeekVRS(Volunteer_Recurrence_Schedule__c vrs, Date dt) {
+		if (vrs.Schedule_Start_Date_Time__c == null) return false;
+		Date dtStart = vrs.Schedule_Start_Date_Time__c.Date().toStartOfWeek();
+		Date dtEnd = dt.toStartOfWeek();
+		integer cdays = dtStart.daysBetween(dtEnd);
+		integer nweeks = (cdays + 1) / 7;
+		return math.mod(nweeks, 2) == 0 ? true : false;		
+	}		
+		
+    //******************************************************************************************************
+	// returns an array of booleans for which days are on the schedule.
+	// note that you should index by nDay (ie, Mon = index 2).
+	private static list<boolean> WhichDaysVRS (Volunteer_Recurrence_Schedule__c vrs) {
+		list<boolean> listWhichDays = new boolean[] { false, false, false, false, false, false, false, false };
+		boolean isSun = VOL_JRS.isSundayFirstOfWeek();
+		
+		if (vrs.Days_of_Week__c != null) {
+			listWhichDays[isSun ? 1 : 7] = vrs.Days_of_Week__c.contains('Sunday');
+			listWhichDays[isSun ? 2 : 1] = vrs.Days_of_Week__c.contains('Monday');
+			listWhichDays[isSun ? 3 : 2] = vrs.Days_of_Week__c.contains('Tuesday');
+			listWhichDays[isSun ? 4 : 3] = vrs.Days_of_Week__c.contains('Wednesday');
+			listWhichDays[isSun ? 5 : 4] = vrs.Days_of_Week__c.contains('Thursday');
+			listWhichDays[isSun ? 6 : 5] = vrs.Days_of_Week__c.contains('Friday');
+			listWhichDays[isSun ? 7 : 6] = vrs.Days_of_Week__c.contains('Saturday');
+		}
+		return listWhichDays; 
+	}
 
     //******************************************************************************************************
-    // given the current date, return the first date in that week that should be scheduled      
-    private static Date dtFirstOccurrenceInWeek(Volunteer_Recurrence_Schedule__c vrs, Date dt) {
-        list<boolean> listWhichDays = WhichDaysVRS(vrs);
-        integer nday = VOL_JRS.nDayOfWeek(dt);
-        integer n;
-        for (n = 1; n < nday && n <= 7; n++) { 
-            if (listWhichDays[n])
-                break;
-        }       
-        return dt.addDays(n - nday);
-    }   
-        
-    
+	// returns an array of booleans for which weeks are on the schedule.
+	// note that you should index by nWeek (ie, first = index 1).
+	private static list<boolean> WhichWeeksVRS(Volunteer_Recurrence_Schedule__c vrs) {
+		list<boolean> listWhichWeeks = new boolean[] { false, false, false, false, false, false };
+		if (vrs.Weekly_Occurrence__c != null) {
+			listWhichWeeks[1] = vrs.Weekly_Occurrence__c.contains('1st');
+			listWhichWeeks[2] = vrs.Weekly_Occurrence__c.contains('2nd');
+			listWhichWeeks[3] = vrs.Weekly_Occurrence__c.contains('3rd');
+			listWhichWeeks[4] = vrs.Weekly_Occurrence__c.contains('4th');
+			listWhichWeeks[5] = vrs.Weekly_Occurrence__c.contains('5th');
+		}
+		return listWhichWeeks;
+	}
+
+    //******************************************************************************************************
+	// given the current date, return the first date in that week that should be scheduled		
+	private static Date dtFirstOccurrenceInWeek(Volunteer_Recurrence_Schedule__c vrs, Date dt) {
+		list<boolean> listWhichDays = WhichDaysVRS(vrs);
+		integer nday = VOL_JRS.nDayOfWeek(dt);
+		integer n;
+		for (n = 1; n < nday && n <= 7; n++) { 
+			if (listWhichDays[n])
+				break;
+		}		
+		return dt.addDays(n - nday);
+	} 	
+		
+	
 }

--- a/src/classes/VOL_VRS.cls
+++ b/src/classes/VOL_VRS.cls
@@ -36,249 +36,262 @@ public with sharing class VOL_VRS {
 
 
     //******************************************************************************************************
-	// for the specified VRS's, delete all hours that are not completed hours.
-	// called from the After Delete VRS trigger.
-	public static void DeleteListVRS(list<Volunteer_Recurrence_Schedule__c> listVRS) {
-		DeleteListVRS(listVRS, false);
-	}
-		
+    // for the specified VRS's, delete all hours that are not completed hours.
+    // called from the After Delete VRS trigger.
+    public static void DeleteListVRS(list<Volunteer_Recurrence_Schedule__c> listVRS) {
+        DeleteListVRS(listVRS, false);
+    }
+        
     //******************************************************************************************************
-	// for the specified VRS's, delete all hours that are not completed hours.
-	// called from the After Delete VRS trigger and when we are processing a modified VRS.
-	private static void DeleteListVRS(list<Volunteer_Recurrence_Schedule__c> listVRS, boolean fPreserveCanceled) {
+    // for the specified VRS's, delete all hours that are not completed hours.
+    // called from the After Delete VRS trigger and when we are processing a modified VRS.
+    private static void DeleteListVRS(list<Volunteer_Recurrence_Schedule__c> listVRS, boolean fPreserveCanceled) {
 
-		// get a set of the VRS ID's for querying
-		set<ID> setVRSId = new set<ID>();
-		for (Volunteer_Recurrence_Schedule__c vrs : listVRS) {
-			setVRSId.add(vrs.Id);
-		}
-		
-		// get all hours associated with these VRS's that we should delete
-		list<Volunteer_Hours__c> listHours = new list<Volunteer_Hours__c>();
-		if (fPreserveCanceled) {
-			listHours = [select Id from Volunteer_Hours__c  
-				where (Status__c <> 'Completed' and Status__c <> 'Canceled' and
-					Volunteer_Recurrence_Schedule__c in : setVRSId)];
-		} else {
-			listHours = [select Id from Volunteer_Hours__c  
-				where (Status__c <> 'Completed' and
-					Volunteer_Recurrence_Schedule__c in : setVRSId)];			
-		}
-				
-		if (listHours.size() > 0) {
-			delete listHours;
-			
-			// if PreserveCanceled, then we know we are updating the VRS, and so there is no need
-			// to keep the deleted Hours in the recycle bin, since we are going to recreate the hours.
-			if (fPreserveCanceled)
-				Database.emptyRecycleBin(listHours);
-		}
-	}
-
-   	//******************************************************************************************************
-	// given a list of Volunteer recurring schedules, does all the work to delete any hours that
-	// no longer match, and creates new hours into the future.
-	// called from both the VRS trigger (when the user modifies a specific VRS),
-	// as well as from the JRS processing, so new shifts get their hours assigned.
-	public static void ProcessListVRS(list<Volunteer_Recurrence_Schedule__c> listVRS) {
-		
-		// get a set of the VRS ID's for querying
-		// also the Job ID's they are associated with
-		// also the contact ID's they are associated with
-		set<ID> setVRSId = new set<ID>();
-		set<ID> setJobId = new set<ID>();
-		set<ID> setContactId = new set<ID>();
-		for (Volunteer_Recurrence_Schedule__c vrs : listVRS) {
-			setVRSId.add(vrs.Id);
-			setJobId.add(vrs.Volunteer_Job__c);
-			setContactId.add(vrs.Contact__c);
-		}
-							
-		// get all shifts of the jobs these vrs's are associated with
-		list<Volunteer_Shift__c> listShift = new list<Volunteer_Shift__c>();
-		listShift = [select Id, Duration__c, Start_Date_Time__c, Desired_Number_of_Volunteers__c, 
-			Volunteer_Job__c from Volunteer_Shift__c
-			where Volunteer_Job__c in :setJobId];
-			
-		// delete all Hours that aren't completed or canceled.
-		DeleteListVRS(listVRS, true);
-		
-		// construct a map of Job to its associated list of VRS's
-		map<ID, list<Volunteer_Recurrence_Schedule__c>> mapJobIdListVRS = new map<ID, list<Volunteer_Recurrence_Schedule__c>>();
-		
-		// put the VRS's on each job's list
-		for (Volunteer_Recurrence_Schedule__c vrs : listVRS) {			
-			list<Volunteer_Recurrence_Schedule__c> listVRSforJob = mapJobIdListVRS.get(vrs.Volunteer_Job__c);
-			if (listVRSforJob == null) listVRSforJob = new list<Volunteer_Recurrence_Schedule__c>();
-			listVRSforJob.add(vrs);
-			mapJobIdListVRS.put(vrs.Volunteer_Job__c, listVRSforJob);				
-		}
-	
-		// in order to avoid creating hours that already exist (completed or canceled),
-		// create a set of shiftId|contactId tuples, which allows us to quickly see if we
-		// already have an hours record for the given shift and contact.
-		list<Volunteer_Hours__c> listHoursExisting = [select Id, Volunteer_Job__c, Volunteer_Recurrence_Schedule__c,
-			Volunteer_Shift__c, Contact__c from
-			Volunteer_Hours__c where Volunteer_Job__c in :setJobId and Contact__c in :setContactId];
-		set<string> setShiftIdContactId = new set<string>();
-		for (Volunteer_Hours__c hr : listHoursExisting) {
-			setShiftIdContactId.add(hr.Volunteer_Shift__c + '|' + hr.Contact__c);
-		}
-
-		// create hours for these vrs's for each shift 				
-		list<Volunteer_Hours__c> listHoursNew = new list<Volunteer_Hours__c>();
-		for (Volunteer_Shift__c shift : listShift) {
-			list<Volunteer_Recurrence_Schedule__c> listVRSforJob = mapJobIdListVRS.get(shift.Volunteer_Job__c);
-			AssignVRSHours(shift, listVRSforJob, setShiftIdContactId, listHoursNew);
-		}
-		if (listHoursNew.size() > 0)
-			insert listHoursNew;								
-		
-	}
-	
-    //******************************************************************************************************
-	// for the specified shift, create VolunteerHours records for all volunteers
-	// who have a recurring schedule which should include this shift.
-	// note that it puts the hours on the provided list, and doesn't actually
-	// save them to the database.
-	public static void AssignVRSHours(
-		Volunteer_Shift__c shift, 
-		list<Volunteer_Recurrence_Schedule__c> listVRS, 
-		set<string> setShiftIdContactId,
-		list<Volunteer_Hours__c> listHoursNew
-		) {
-			
-		if (listVRS == null) return; 
-
-		// Strategy:
-		// for the given shift, go through the list of VRS's
-		// and create hours for the ones that match.
-		
-		// we decided not to limit the number of volunteers assigned
-		//integer cDesiredVols = 1000;
-		//if (shift.Desired_Number_of_Volunteers__c != null) 
-		//	cDesiredVols = integer.valueOf(shift.Desired_Number_of_Volunteers__c);
-		Date dtShift = shift.Start_Date_Time__c.Date();
-		DateTime dtShiftEnd = shift.Start_Date_Time__c.addMinutes(integer.valueOf(shift.Duration__c * 60));
-		integer nday = VOL_JRS.nDayOfWeek(dtShift);
-		
-		for (Volunteer_Recurrence_Schedule__c vrs : listVRS) {
-		
-			// exit if we've filled all the slots.
-			//if (cDesiredVols <= 0) 
-				//break;
-	
-			// for this jrs, what week should we treat this shift as
-			integer nweek = VOL_JRS.nWeekOfDate(dtFirstOccurrenceInWeek(vrs, dtShift));
-		
-			list<boolean> listWhichDays = WhichDaysVRS(vrs);
-			list<boolean> listWhichWeeks = WhichWeeksVRS(vrs);
-			
-			if (vrs.Weekly_Occurrence__c == null)
-				continue;
-			
-			if ((listWhichWeeks[nweek] || 
-					vrs.Weekly_Occurrence__c.contains('Every') ||
-					(vrs.Weekly_Occurrence__c.contains('Alternate') && alternateWeekVRS(vrs, dtShift))) && 
-				listWhichDays[nday] &&
-				vrs.Schedule_Start_Date_Time__c != null &&
-				dtShift >= vrs.Schedule_Start_Date_Time__c.Date() &&
-				(vrs.Schedule_End_Date__c == null || vrs.Schedule_End_Date__c >= dtShift)) {
-					
-				// we need to deal with the person already having hours on this shift
-				// that might be completed, or canceled, or web signup.  
-				// avoid creating another confirmed record.
-				if (setShiftIdContactId.contains(shift.Id + '|' + vrs.Contact__c)) {
-					continue;
-				}
-									
-				// only take volunteers whose time fits in the shift time (to handle multiple shifts per day)
-				Time tmVRS = vrs.Schedule_Start_Date_Time__c.Time();				
-				DateTime dtVRSStart =  datetime.newInstance(dtShift, tmVRS);
-				if (dtVRSStart < shift.Start_Date_Time__c  || dtVRSStart >= dtShiftEnd) {
-					continue;					
-				}	
-					
-				Volunteer_Hours__c hr = new Volunteer_Hours__c();
-				hr.System_Note__c = label.labelVRSHoursCreatedSystemNote + ' ' + vrs.Name + '.';
-				hr.Contact__c = vrs.Contact__c;
-				hr.Hours_Worked__c = vrs.Duration__c;
-				hr.Number_of_Volunteers__c = 1;
-				if (vrs.Number_of_Volunteers__c != null && vrs.Number_of_Volunteers__c > 1)
-					hr.Number_of_Volunteers__c = vrs.Number_of_Volunteers__c; 
-				hr.Start_Date__c = dtShift;
-				hr.End_Date__c = dtShift;
-				hr.Status__c = (vrs.Volunteer_Hours_Status__c == null ? 'Confirmed' : vrs.Volunteer_Hours_Status__c);
-				hr.Volunteer_Job__c = shift.Volunteer_Job__c;
-				hr.Volunteer_Shift__c = shift.Id;	
-				hr.Volunteer_Recurrence_Schedule__c = vrs.Id;	
-				hr.Planned_Start_Date_Time__c = datetime.newInstance(shift.Start_Date_Time__c.date(), vrs.Schedule_Start_Date_Time__c.time());
-				hr.Comments__c = vrs.Comments__c;
-				listHoursNew.add(hr);
-				//cDesiredVols--;
-			}			 		
-		}
-		
-		// we let the caller commit the new hours to the db.		
-	}
+        // get a set of the VRS ID's for querying
+        set<ID> setVRSId = new set<ID>();
+        for (Volunteer_Recurrence_Schedule__c vrs : listVRS) {
+            setVRSId.add(vrs.Id);
+        }
+        
+        // get all hours associated with these VRS's that we should delete
+        list<Volunteer_Hours__c> listHours = new list<Volunteer_Hours__c>();
+        if (fPreserveCanceled) {
+            listHours = [select Id from Volunteer_Hours__c  
+                where (Status__c <> 'Completed' and Status__c <> 'Canceled' and
+                    Volunteer_Recurrence_Schedule__c in : setVRSId)];
+        } else {
+            listHours = [select Id from Volunteer_Hours__c  
+                where (Status__c <> 'Completed' and
+                    Volunteer_Recurrence_Schedule__c in : setVRSId)];           
+        }
+                
+        if (listHours.size() > 0) {
+            delete listHours;
+            
+            // if PreserveCanceled, then we know we are updating the VRS, and so there is no need
+            // to keep the deleted Hours in the recycle bin, since we are going to recreate the hours.
+            if (fPreserveCanceled)
+                Database.emptyRecycleBin(listHours);
+        }
+    }
 
     //******************************************************************************************************
-	// returns whether the nweek of the specified date is an alternate week for this schedule
-	public static boolean alternateWeekVRS(Volunteer_Recurrence_Schedule__c vrs, Date dt) {
-		if (vrs.Schedule_Start_Date_Time__c == null) return false;
-		Date dtStart = vrs.Schedule_Start_Date_Time__c.Date().toStartOfWeek();
-		Date dtEnd = dt.toStartOfWeek();
-		integer cdays = dtStart.daysBetween(dtEnd);
-		integer nweeks = (cdays + 1) / 7;
-		return math.mod(nweeks, 2) == 0 ? true : false;		
-	}		
-		
+    // given a list of Volunteer recurring schedules, does all the work to delete any hours that
+    // no longer match, and creates new hours into the future.
+    // called from both the VRS trigger (when the user modifies a specific VRS),
+    // as well as from the JRS processing, so new shifts get their hours assigned.
+    public static void ProcessListVRS(list<Volunteer_Recurrence_Schedule__c> listVRS) {
+        
+        // get a set of the VRS ID's for querying
+        // also the Job ID's they are associated with
+        // also the contact ID's they are associated with
+        set<ID> setVRSId = new set<ID>();
+        set<ID> setJobId = new set<ID>();
+        set<ID> setContactId = new set<ID>();
+        for (Volunteer_Recurrence_Schedule__c vrs : listVRS) {
+            setVRSId.add(vrs.Id);
+            setJobId.add(vrs.Volunteer_Job__c);
+            setContactId.add(vrs.Contact__c);
+        }
+                            
+        // get all shifts of the jobs these vrs's are associated with
+        list<Volunteer_Shift__c> listShift = new list<Volunteer_Shift__c>();
+        listShift = [select Id, Duration__c, Start_Date_Time__c, Desired_Number_of_Volunteers__c, 
+            Volunteer_Job__c from Volunteer_Shift__c
+            where Volunteer_Job__c in :setJobId];
+            
+        // construct a map of Job to its associated list of VRS's
+        map<ID, list<Volunteer_Recurrence_Schedule__c>> mapJobIdListVRS = new map<ID, list<Volunteer_Recurrence_Schedule__c>>();
+        
+        // put the VRS's on each job's list
+        for (Volunteer_Recurrence_Schedule__c vrs : listVRS) {          
+            list<Volunteer_Recurrence_Schedule__c> listVRSforJob = mapJobIdListVRS.get(vrs.Volunteer_Job__c);
+            if (listVRSforJob == null) listVRSforJob = new list<Volunteer_Recurrence_Schedule__c>();
+            listVRSforJob.add(vrs);
+            mapJobIdListVRS.put(vrs.Volunteer_Job__c, listVRSforJob);               
+        }
+    
+        // in order to avoid creating hours that already exist (completed or canceled),
+        // create a set of shiftId|contactId tuples, which allows us to quickly see if we
+        // already have an hours record for the given shift and contact.
+        list<Volunteer_Hours__c> listHoursExisting = [select Id, Volunteer_Job__c, Volunteer_Recurrence_Schedule__c,
+            Volunteer_Shift__c, Status__c, Contact__c from
+            Volunteer_Hours__c where Volunteer_Job__c in :setJobId and Contact__c in :setContactId];
+        map<string, Volunteer_Hours__c> mapShiftIdContactIdToHours = new map<string, Volunteer_Hours__c>();
+        for (Volunteer_Hours__c hr : listHoursExisting) {
+            mapShiftIdContactIdToHours.put(hr.Volunteer_Shift__c + '|' + hr.Contact__c, hr);
+        }
+
+        // create hours for these vrs's for each shift              
+        list<Volunteer_Hours__c> listHoursNew = new list<Volunteer_Hours__c>();
+        for (Volunteer_Shift__c shift : listShift) {
+            list<Volunteer_Recurrence_Schedule__c> listVRSforJob = mapJobIdListVRS.get(shift.Volunteer_Job__c);
+            AssignVRSHours(shift, listVRSforJob, mapShiftIdContactIdToHours, listHoursNew);
+        }
+        if (listHoursNew.size() > 0)
+            insert listHoursNew;
+            
+        // mapShiftIdContactIdToHours now contains only the Hours that did not match the VRS's, 
+        // so we can delete them if they aren't marked Completed or Canceled.
+        list<Volunteer_Hours__c> listHRDelete = new list<Volunteer_Hours__c>();
+        for (Volunteer_Hours__c hr : mapShiftIdContactIdToHours.values()) {
+            if (hr.Status__c != 'Completed' && hr.Status__c != 'Canceled') {
+                listHRDelete.add(hr);
+            }
+        }
+        if (listHRDelete.size() > 0)
+            delete listHRDelete;
+    }
+    
     //******************************************************************************************************
-	// returns an array of booleans for which days are on the schedule.
-	// note that you should index by nDay (ie, Mon = index 2).
-	private static list<boolean> WhichDaysVRS (Volunteer_Recurrence_Schedule__c vrs) {
-		list<boolean> listWhichDays = new boolean[] { false, false, false, false, false, false, false, false };
-		boolean isSun = VOL_JRS.isSundayFirstOfWeek();
-		
-		if (vrs.Days_of_Week__c != null) {
-			listWhichDays[isSun ? 1 : 7] = vrs.Days_of_Week__c.contains('Sunday');
-			listWhichDays[isSun ? 2 : 1] = vrs.Days_of_Week__c.contains('Monday');
-			listWhichDays[isSun ? 3 : 2] = vrs.Days_of_Week__c.contains('Tuesday');
-			listWhichDays[isSun ? 4 : 3] = vrs.Days_of_Week__c.contains('Wednesday');
-			listWhichDays[isSun ? 5 : 4] = vrs.Days_of_Week__c.contains('Thursday');
-			listWhichDays[isSun ? 6 : 5] = vrs.Days_of_Week__c.contains('Friday');
-			listWhichDays[isSun ? 7 : 6] = vrs.Days_of_Week__c.contains('Saturday');
-		}
-		return listWhichDays; 
-	}
+    // @description for the specified shift, create VolunteerHours records for all volunteers
+    // who have a recurring schedule which should include this shift.
+    // @param shift The shift to assign Hours to
+    // @param listVRS The list of VRS's to consider for assigning hours to the shift
+    // @param mapShiftIdContactIdToHours A map of shiftId/ContactId keys to existing Hours.  As Hours are
+    // matched, they are removed from this map.  So upon return, this map contains those Hours that no longer
+    // match their VRS (so they can be considered for deletion).
+    // @param listHoursNew The returned set of Hours to create (leaving creation to the caller)
+    private static void AssignVRSHours(
+        Volunteer_Shift__c shift, 
+        list<Volunteer_Recurrence_Schedule__c> listVRS, 
+        map<string, Volunteer_Hours__c> mapShiftIdContactIdToHours,
+        list<Volunteer_Hours__c> listHoursNew
+        ) {
+            
+        if (listVRS == null) return; 
+
+        // Strategy:
+        // for the given shift, go through the list of VRS's
+        // and create hours for the ones that match.
+        
+        // we decided not to limit the number of volunteers assigned
+        //integer cDesiredVols = 1000;
+        //if (shift.Desired_Number_of_Volunteers__c != null) 
+        //  cDesiredVols = integer.valueOf(shift.Desired_Number_of_Volunteers__c);
+        Date dtShift = shift.Start_Date_Time__c.Date();
+        DateTime dtShiftEnd = shift.Start_Date_Time__c.addMinutes(integer.valueOf(shift.Duration__c * 60));
+        integer nday = VOL_JRS.nDayOfWeek(dtShift);
+        
+        for (Volunteer_Recurrence_Schedule__c vrs : listVRS) {
+        
+            // exit if we've filled all the slots.
+            //if (cDesiredVols <= 0) 
+                //break;
+    
+            // for this jrs, what week should we treat this shift as
+            integer nweek = VOL_JRS.nWeekOfDate(dtFirstOccurrenceInWeek(vrs, dtShift));
+        
+            list<boolean> listWhichDays = WhichDaysVRS(vrs);
+            list<boolean> listWhichWeeks = WhichWeeksVRS(vrs);
+            
+            if (vrs.Weekly_Occurrence__c == null)
+                continue;
+            
+            if ((listWhichWeeks[nweek] || 
+                    vrs.Weekly_Occurrence__c.contains('Every') ||
+                    (vrs.Weekly_Occurrence__c.contains('Alternate') && alternateWeekVRS(vrs, dtShift))) && 
+                listWhichDays[nday] &&
+                vrs.Schedule_Start_Date_Time__c != null &&
+                dtShift >= vrs.Schedule_Start_Date_Time__c.Date() &&
+                (vrs.Schedule_End_Date__c == null || vrs.Schedule_End_Date__c >= dtShift)) {
+                    
+                // we need to deal with the person already having hours on this shift
+                // that might be completed, or canceled, or web signup.  
+                // avoid creating another confirmed record.
+                // note that if we match, we remove the key from the map, so we know it was matched.
+                if (mapShiftIdContactIdToHours.containsKey(shift.Id + '|' + vrs.Contact__c)) {
+                    mapShiftIdContactIdToHours.remove(shift.Id + '|' + vrs.Contact__c);
+                    continue;
+                }
+                                    
+                // only take volunteers whose time fits in the shift time (to handle multiple shifts per day)
+                Time tmVRS = vrs.Schedule_Start_Date_Time__c.Time();                
+                DateTime dtVRSStart =  datetime.newInstance(dtShift, tmVRS);
+                if (dtVRSStart < shift.Start_Date_Time__c  || dtVRSStart >= dtShiftEnd) {
+                    continue;                   
+                }   
+                    
+                Volunteer_Hours__c hr = new Volunteer_Hours__c();
+                hr.System_Note__c = label.labelVRSHoursCreatedSystemNote + ' ' + vrs.Name + '.';
+                hr.Contact__c = vrs.Contact__c;
+                hr.Hours_Worked__c = vrs.Duration__c;
+                hr.Number_of_Volunteers__c = 1;
+                if (vrs.Number_of_Volunteers__c != null && vrs.Number_of_Volunteers__c > 1)
+                    hr.Number_of_Volunteers__c = vrs.Number_of_Volunteers__c; 
+                hr.Start_Date__c = dtShift;
+                hr.End_Date__c = dtShift;
+                hr.Status__c = (vrs.Volunteer_Hours_Status__c == null ? 'Confirmed' : vrs.Volunteer_Hours_Status__c);
+                hr.Volunteer_Job__c = shift.Volunteer_Job__c;
+                hr.Volunteer_Shift__c = shift.Id;   
+                hr.Volunteer_Recurrence_Schedule__c = vrs.Id;   
+                hr.Planned_Start_Date_Time__c = datetime.newInstance(shift.Start_Date_Time__c.date(), vrs.Schedule_Start_Date_Time__c.time());
+                hr.Comments__c = vrs.Comments__c;
+                listHoursNew.add(hr);
+                //cDesiredVols--;
+            }                   
+        }
+        
+        // we let the caller commit the new hours to the db.        
+    }
 
     //******************************************************************************************************
-	// returns an array of booleans for which weeks are on the schedule.
-	// note that you should index by nWeek (ie, first = index 1).
-	private static list<boolean> WhichWeeksVRS(Volunteer_Recurrence_Schedule__c vrs) {
-		list<boolean> listWhichWeeks = new boolean[] { false, false, false, false, false, false };
-		if (vrs.Weekly_Occurrence__c != null) {
-			listWhichWeeks[1] = vrs.Weekly_Occurrence__c.contains('1st');
-			listWhichWeeks[2] = vrs.Weekly_Occurrence__c.contains('2nd');
-			listWhichWeeks[3] = vrs.Weekly_Occurrence__c.contains('3rd');
-			listWhichWeeks[4] = vrs.Weekly_Occurrence__c.contains('4th');
-			listWhichWeeks[5] = vrs.Weekly_Occurrence__c.contains('5th');
-		}
-		return listWhichWeeks;
-	}
+    // returns whether the nweek of the specified date is an alternate week for this schedule
+    public static boolean alternateWeekVRS(Volunteer_Recurrence_Schedule__c vrs, Date dt) {
+        if (vrs.Schedule_Start_Date_Time__c == null) return false;
+        Date dtStart = vrs.Schedule_Start_Date_Time__c.Date().toStartOfWeek();
+        Date dtEnd = dt.toStartOfWeek();
+        integer cdays = dtStart.daysBetween(dtEnd);
+        integer nweeks = (cdays + 1) / 7;
+        return math.mod(nweeks, 2) == 0 ? true : false;     
+    }       
+        
+    //******************************************************************************************************
+    // returns an array of booleans for which days are on the schedule.
+    // note that you should index by nDay (ie, Mon = index 2).
+    private static list<boolean> WhichDaysVRS (Volunteer_Recurrence_Schedule__c vrs) {
+        list<boolean> listWhichDays = new boolean[] { false, false, false, false, false, false, false, false };
+        boolean isSun = VOL_JRS.isSundayFirstOfWeek();
+        
+        if (vrs.Days_of_Week__c != null) {
+            listWhichDays[isSun ? 1 : 7] = vrs.Days_of_Week__c.contains('Sunday');
+            listWhichDays[isSun ? 2 : 1] = vrs.Days_of_Week__c.contains('Monday');
+            listWhichDays[isSun ? 3 : 2] = vrs.Days_of_Week__c.contains('Tuesday');
+            listWhichDays[isSun ? 4 : 3] = vrs.Days_of_Week__c.contains('Wednesday');
+            listWhichDays[isSun ? 5 : 4] = vrs.Days_of_Week__c.contains('Thursday');
+            listWhichDays[isSun ? 6 : 5] = vrs.Days_of_Week__c.contains('Friday');
+            listWhichDays[isSun ? 7 : 6] = vrs.Days_of_Week__c.contains('Saturday');
+        }
+        return listWhichDays; 
+    }
 
     //******************************************************************************************************
-	// given the current date, return the first date in that week that should be scheduled		
-	private static Date dtFirstOccurrenceInWeek(Volunteer_Recurrence_Schedule__c vrs, Date dt) {
-		list<boolean> listWhichDays = WhichDaysVRS(vrs);
-		integer nday = VOL_JRS.nDayOfWeek(dt);
-		integer n;
-		for (n = 1; n < nday && n <= 7; n++) { 
-			if (listWhichDays[n])
-				break;
-		}		
-		return dt.addDays(n - nday);
-	} 	
-		
-	
+    // returns an array of booleans for which weeks are on the schedule.
+    // note that you should index by nWeek (ie, first = index 1).
+    private static list<boolean> WhichWeeksVRS(Volunteer_Recurrence_Schedule__c vrs) {
+        list<boolean> listWhichWeeks = new boolean[] { false, false, false, false, false, false };
+        if (vrs.Weekly_Occurrence__c != null) {
+            listWhichWeeks[1] = vrs.Weekly_Occurrence__c.contains('1st');
+            listWhichWeeks[2] = vrs.Weekly_Occurrence__c.contains('2nd');
+            listWhichWeeks[3] = vrs.Weekly_Occurrence__c.contains('3rd');
+            listWhichWeeks[4] = vrs.Weekly_Occurrence__c.contains('4th');
+            listWhichWeeks[5] = vrs.Weekly_Occurrence__c.contains('5th');
+        }
+        return listWhichWeeks;
+    }
+
+    //******************************************************************************************************
+    // given the current date, return the first date in that week that should be scheduled      
+    private static Date dtFirstOccurrenceInWeek(Volunteer_Recurrence_Schedule__c vrs, Date dt) {
+        list<boolean> listWhichDays = WhichDaysVRS(vrs);
+        integer nday = VOL_JRS.nDayOfWeek(dt);
+        integer n;
+        for (n = 1; n < nday && n <= 7; n++) { 
+            if (listWhichDays[n])
+                break;
+        }       
+        return dt.addDays(n - nday);
+    }   
+        
+    
 }

--- a/src/classes/VOL_VRS_TEST.cls
+++ b/src/classes/VOL_VRS_TEST.cls
@@ -329,4 +329,75 @@ public with sharing class VOL_VRS_TEST {
         }
         
     }
+
+    //******************************************************************************************************
+    // Test updating existing Volunteer Recurrence Schedule's job, deletes old hours and creates new hours.
+    public static testmethod void TestVRSHoursChangeJob() {
+
+        // create test data
+        Campaign cmp = new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, 
+            name='Job Calendar Test Campaign', IsActive=true);
+        insert cmp;
+        Volunteer_Job__c job = new Volunteer_Job__c(name='Job1', campaign__c=cmp.Id);
+        insert job;
+        Volunteer_Job__c job2 = new Volunteer_Job__c(name='Job2', campaign__c=cmp.Id);
+        insert job2;
+        Contact contact = new Contact(firstname='test', lastname='test');
+        insert contact;
+        
+        Job_Recurrence_Schedule__c jrs = new Job_Recurrence_Schedule__c(Volunteer_Job__c = job.Id);
+        jrs.Days_of_Week__c = 'Monday;Wednesday;Friday';
+        jrs.Duration__c = 1;
+        jrs.Schedule_Start_Date_Time__c = system.today().toStartOfMonth();
+        jrs.Schedule_End_Date__c = system.today().addMonths(2).toStartOfMonth().addDays(-1);
+        jrs.Weekly_Occurrence__c = '2nd';
+        jrs.Desired_Number_of_Volunteers__c = 5;
+        insert jrs;
+
+        Job_Recurrence_Schedule__c jrs2 = new Job_Recurrence_Schedule__c(Volunteer_Job__c = job2.Id);
+        jrs2.Days_of_Week__c = 'Monday;Wednesday;Friday';
+        jrs2.Duration__c = 1;
+        jrs2.Schedule_Start_Date_Time__c = system.today().toStartOfMonth();
+        jrs2.Schedule_End_Date__c = system.today().addMonths(2).toStartOfMonth().addDays(-1);
+        jrs2.Weekly_Occurrence__c = '2nd';
+        jrs2.Desired_Number_of_Volunteers__c = 5;
+        insert jrs2;
+        
+        list<Volunteer_Shift__c> listShift = [select Id, Name, Volunteer_Job__r.Name from Volunteer_Shift__c where Job_Recurrence_Schedule__c = :jrs.Id];
+        system.assertEquals(6, listShift.size());
+        
+        Volunteer_Recurrence_Schedule__c vrs = new Volunteer_Recurrence_Schedule__c(
+            Contact__c = contact.Id, 
+            Volunteer_Job__c = job.Id,
+            Volunteer_Hours_Status__c = 'My Custom Status',
+            Days_of_Week__c = 'Monday;Wednesday',
+            Duration__c = 1.5,
+            Number_of_Volunteers__c = 2,
+            Comments__c = 'my comments!',
+            Schedule_Start_Date_Time__c = system.today().toStartOfMonth(),
+            Schedule_End_Date__c = system.today().addMonths(2).toStartOfMonth().addDays(-1),
+            Weekly_Occurrence__c = '2nd');
+        insert vrs;
+        Volunteer_Recurrence_Schedule__c vrsOriginal = vrs.clone();
+        
+        list<Volunteer_Hours__c> listHours = [select Id, Status__c, Number_of_Volunteers__c, Comments__c 
+            from Volunteer_Hours__c where Volunteer_Recurrence_Schedule__c = :vrs.Id order by Planned_Start_Date_Time__c];
+        system.assertEquals(4, listHours.size());
+        system.assertEquals(vrs.Number_of_Volunteers__c, listHours[0].Number_of_Volunteers__c);
+        system.assertEquals(vrs.Comments__c, listHours[0].Comments__c);
+        
+        // update the Job
+        vrs.Volunteer_Job__c = job2.Id;
+        Test.startTest();
+        update vrs;
+        Test.stopTest(); 
+
+        listHours = [select Id, Status__c, Planned_Start_Date_Time__c, Hours_Worked__c, Number_Of_Volunteers__c, Comments__c 
+            from Volunteer_Hours__c where Volunteer_Job__c = :job.Id];
+        system.assertEquals(0, listHours.size());
+        
+        listHours = [select Id, Status__c, Planned_Start_Date_Time__c, Hours_Worked__c, Number_Of_Volunteers__c, Comments__c 
+            from Volunteer_Hours__c where Volunteer_Job__c = :job2.Id];
+        system.assertEquals(4, listHours.size());        
+   }
 }

--- a/src/classes/VOL_VRS_TEST.cls
+++ b/src/classes/VOL_VRS_TEST.cls
@@ -161,7 +161,6 @@ public with sharing class VOL_VRS_TEST {
         Test.stopTest(); 
         
         list<Volunteer_Shift__c> listShift = [select Id, Name, Volunteer_Job__r.Name from Volunteer_Shift__c where Job_Recurrence_Schedule__c = :jrs.Id];
-        //system.debug(listShift);
         system.assertEquals(6, listShift.size());
         
         list<Volunteer_Hours__c> listHours = [select Id, Status__c, Number_of_Volunteers__c, Comments__c 
@@ -171,7 +170,6 @@ public with sharing class VOL_VRS_TEST {
         system.assertEquals(vrs.Comments__c, listHours[0].Comments__c);
         
         listHours[0].Status__c = 'No-Show';
-        //system.debug('****DJH updating hr: '+ listHours[0]); 
         update listHours[0];
         
         vrs.Days_of_Week__c = 'Monday;Friday';
@@ -179,16 +177,15 @@ public with sharing class VOL_VRS_TEST {
         update vrs;
 
         listHours = [select Id, Status__c, Planned_Start_Date_Time__c from Volunteer_Hours__c where Volunteer_Recurrence_Schedule__c = :vrs.Id order by Planned_Start_Date_Time__c];
-        //system.debug('****DJH listHours: ' + listHours);
         
         listHours = [select Id, Status__c from Volunteer_Hours__c where Status__c = 'My Custom Status' and Volunteer_Recurrence_Schedule__c = :vrs.Id];
-        system.assertEquals(1, listHours.size());  // first Monday was changed to no-show
+        system.assertEquals(0, listHours.size());  
         
         listHours = [select Id, Status__c from Volunteer_Hours__c where Status__c = 'No-Show' and Volunteer_Recurrence_Schedule__c = :vrs.Id];
         system.assertEquals(1, listHours.size());  
 
         listHours = [select Id, Status__c from Volunteer_Hours__c where Status__c = 'Confirmed' and Volunteer_Recurrence_Schedule__c = :vrs.Id];
-        system.assertEquals(2, listHours.size());  
+        system.assertEquals(3, listHours.size());  
     }
     
     //******************************************************************************************************
@@ -248,13 +245,13 @@ public with sharing class VOL_VRS_TEST {
         system.assertEquals(4, listHours.size());
         
         listHours = [select Id, Status__c from Volunteer_Hours__c where Status__c = 'My Custom Status'];
-        system.assertEquals(1, listHours.size());  
+        system.assertEquals(0, listHours.size());  
         
         listHours = [select Id, Status__c from Volunteer_Hours__c where Status__c = 'Completed'];
         system.assertEquals(1, listHours.size());  
         
         listHours = [select Id, Status__c from Volunteer_Hours__c where Status__c = 'Confirmed'];
-        system.assertEquals(2, listHours.size());  
+        system.assertEquals(3, listHours.size());  
     }
 
     //******************************************************************************************************

--- a/src/classes/VOL_VRS_TEST.cls
+++ b/src/classes/VOL_VRS_TEST.cls
@@ -161,7 +161,7 @@ public with sharing class VOL_VRS_TEST {
         Test.stopTest(); 
         
         list<Volunteer_Shift__c> listShift = [select Id, Name, Volunteer_Job__r.Name from Volunteer_Shift__c where Job_Recurrence_Schedule__c = :jrs.Id];
-        system.debug(listShift);
+        //system.debug(listShift);
         system.assertEquals(6, listShift.size());
         
         list<Volunteer_Hours__c> listHours = [select Id, Status__c, Number_of_Volunteers__c, Comments__c 
@@ -171,7 +171,7 @@ public with sharing class VOL_VRS_TEST {
         system.assertEquals(vrs.Comments__c, listHours[0].Comments__c);
         
         listHours[0].Status__c = 'No-Show';
-        system.debug('****DJH updating hr: '+ listHours[0]); 
+        //system.debug('****DJH updating hr: '+ listHours[0]); 
         update listHours[0];
         
         vrs.Days_of_Week__c = 'Monday;Friday';
@@ -179,7 +179,7 @@ public with sharing class VOL_VRS_TEST {
         update vrs;
 
         listHours = [select Id, Status__c, Planned_Start_Date_Time__c from Volunteer_Hours__c where Volunteer_Recurrence_Schedule__c = :vrs.Id order by Planned_Start_Date_Time__c];
-		system.debug('****DJH listHours: ' + listHours);
+        //system.debug('****DJH listHours: ' + listHours);
         
         listHours = [select Id, Status__c from Volunteer_Hours__c where Status__c = 'My Custom Status' and Volunteer_Recurrence_Schedule__c = :vrs.Id];
         system.assertEquals(1, listHours.size());  // first Monday was changed to no-show
@@ -189,7 +189,147 @@ public with sharing class VOL_VRS_TEST {
 
         listHours = [select Id, Status__c from Volunteer_Hours__c where Status__c = 'Confirmed' and Volunteer_Recurrence_Schedule__c = :vrs.Id];
         system.assertEquals(2, listHours.size());  
-        
     }
     
+    //******************************************************************************************************
+    // Test updating existing Volunteer Recurrence Schedules deletes Hours that no longer match VRS
+    public static testmethod void TestVRSHoursDelete() {
+
+        // create test data
+        Campaign cmp = new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, 
+            name='Job Calendar Test Campaign', IsActive=true);
+        insert cmp;
+        Volunteer_Job__c job = new Volunteer_Job__c(name='Job1', campaign__c=cmp.Id);
+        insert job;
+        Contact contact = new Contact(firstname='test', lastname='test');
+        insert contact;
+        
+        Job_Recurrence_Schedule__c jrs = new Job_Recurrence_Schedule__c(Volunteer_Job__c = job.Id);
+        jrs.Days_of_Week__c = 'Monday;Wednesday;Friday';
+        jrs.Duration__c = 1;
+        jrs.Schedule_Start_Date_Time__c = date.newInstance(2016,11,1);
+        jrs.Schedule_End_Date__c = date.newInstance(2016,12,31);
+        jrs.Weekly_Occurrence__c = '2nd';
+        jrs.Desired_Number_of_Volunteers__c = 5;
+        insert jrs;
+        
+        list<Volunteer_Shift__c> listShift = [select Id, Name, Volunteer_Job__r.Name from Volunteer_Shift__c where Job_Recurrence_Schedule__c = :jrs.Id];
+        system.assertEquals(6, listShift.size());
+        
+        Volunteer_Recurrence_Schedule__c vrs = new Volunteer_Recurrence_Schedule__c(
+            Contact__c = contact.Id, 
+            Volunteer_Job__c = job.Id,
+            Volunteer_Hours_Status__c = 'My Custom Status',
+            Days_of_Week__c = 'Monday;Wednesday',
+            Duration__c = 1.5,
+            Number_of_Volunteers__c = 2,
+            Comments__c = 'my comments!',
+            Schedule_Start_Date_Time__c = date.newInstance(2016,11,1),
+            Schedule_End_Date__c = date.newInstance(2016,12,31),
+            Weekly_Occurrence__c = '2nd');
+        insert vrs;
+        
+        list<Volunteer_Hours__c> listHours = [select Id, Status__c, Number_of_Volunteers__c, Comments__c 
+            from Volunteer_Hours__c where Volunteer_Recurrence_Schedule__c = :vrs.Id order by Planned_Start_Date_Time__c];
+        system.assertEquals(4, listHours.size());
+        system.assertEquals(vrs.Number_of_Volunteers__c, listHours[0].Number_of_Volunteers__c);
+        system.assertEquals(vrs.Comments__c, listHours[0].Comments__c);
+        
+        listHours[0].Status__c = 'Completed';
+        update listHours[0];
+        
+        vrs.Days_of_Week__c = 'Monday;Friday';
+        vrs.Volunteer_Hours_Status__c = 'Confirmed';
+        Test.startTest();
+        update vrs;
+        Test.stopTest(); 
+
+        listHours = [select Id, Status__c, Planned_Start_Date_Time__c from Volunteer_Hours__c];
+        system.assertEquals(4, listHours.size());
+        
+        listHours = [select Id, Status__c from Volunteer_Hours__c where Status__c = 'My Custom Status'];
+        system.assertEquals(1, listHours.size());  
+        
+        listHours = [select Id, Status__c from Volunteer_Hours__c where Status__c = 'Completed'];
+        system.assertEquals(1, listHours.size());  
+        
+        listHours = [select Id, Status__c from Volunteer_Hours__c where Status__c = 'Confirmed'];
+        system.assertEquals(2, listHours.size());  
+    }
+
+    //******************************************************************************************************
+    // Test updating existing Volunteer Recurrence Schedules reuses, but updates, Hours
+    public static testmethod void TestVRSHoursHoursReuse() {
+
+        // create test data
+        Campaign cmp = new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, 
+            name='Job Calendar Test Campaign', IsActive=true);
+        insert cmp;
+        Volunteer_Job__c job = new Volunteer_Job__c(name='Job1', campaign__c=cmp.Id);
+        insert job;
+        Contact contact = new Contact(firstname='test', lastname='test');
+        insert contact;
+        
+        Job_Recurrence_Schedule__c jrs = new Job_Recurrence_Schedule__c(Volunteer_Job__c = job.Id);
+        jrs.Days_of_Week__c = 'Monday;Wednesday;Friday';
+        jrs.Duration__c = 1;
+        jrs.Schedule_Start_Date_Time__c = system.today().toStartOfMonth();
+        jrs.Schedule_End_Date__c = system.today().addMonths(2).toStartOfMonth().addDays(-1);
+        jrs.Weekly_Occurrence__c = '2nd';
+        jrs.Desired_Number_of_Volunteers__c = 5;
+        insert jrs;
+        
+        list<Volunteer_Shift__c> listShift = [select Id, Name, Volunteer_Job__r.Name from Volunteer_Shift__c where Job_Recurrence_Schedule__c = :jrs.Id];
+        system.assertEquals(6, listShift.size());
+        
+        Volunteer_Recurrence_Schedule__c vrs = new Volunteer_Recurrence_Schedule__c(
+            Contact__c = contact.Id, 
+            Volunteer_Job__c = job.Id,
+            Volunteer_Hours_Status__c = 'My Custom Status',
+            Days_of_Week__c = 'Monday;Wednesday',
+            Duration__c = 1.5,
+            Number_of_Volunteers__c = 2,
+            Comments__c = 'my comments!',
+            Schedule_Start_Date_Time__c = system.today().toStartOfMonth(),
+            Schedule_End_Date__c = system.today().addMonths(2).toStartOfMonth().addDays(-1),
+            Weekly_Occurrence__c = '2nd');
+        insert vrs;
+        Volunteer_Recurrence_Schedule__c vrsOriginal = vrs.clone();
+        
+        list<Volunteer_Hours__c> listHours = [select Id, Status__c, Number_of_Volunteers__c, Comments__c 
+            from Volunteer_Hours__c where Volunteer_Recurrence_Schedule__c = :vrs.Id order by Planned_Start_Date_Time__c];
+        system.assertEquals(4, listHours.size());
+        system.assertEquals(vrs.Number_of_Volunteers__c, listHours[0].Number_of_Volunteers__c);
+        system.assertEquals(vrs.Comments__c, listHours[0].Comments__c);
+        
+        // update all fields that should update future hours, but not past hours
+        vrs.Volunteer_Hours_Status__c = 'Confirmed';
+        vrs.Duration__c = 1;
+        vrs.Number_of_Volunteers__c = 1;
+        vrs.Comments__c = 'new comments';
+        vrs.Schedule_Start_Date_Time__c = vrs.Schedule_Start_Date_Time__c.addMinutes(10);
+        Test.startTest();
+        update vrs;
+        Test.stopTest(); 
+
+        listHours = [select Id, Status__c, Planned_Start_Date_Time__c, Hours_Worked__c, Number_Of_Volunteers__c, Comments__c from Volunteer_Hours__c];
+        system.assertEquals(4, listHours.size());
+        
+        for (Volunteer_Hours__c hr : listHours) {
+            if (hr.Planned_Start_Date_Time__c >= system.Today()) {
+                system.assertEquals(vrs.Volunteer_Hours_Status__c, hr.Status__c);
+                system.assertEquals(vrs.Duration__c, hr.Hours_Worked__c);
+                system.assertEquals(vrs.Number_of_Volunteers__c, hr.Number_of_Volunteers__c);
+                system.assertEquals(vrs.Comments__c, hr.Comments__c);
+                system.assertEquals(vrs.Schedule_Start_Date_Time__c.Time(), hr.Planned_Start_Date_Time__c.Time());
+            } else {
+                system.assertEquals(vrsOriginal.Volunteer_Hours_Status__c, hr.Status__c);
+                system.assertEquals(vrsOriginal.Duration__c, hr.Hours_Worked__c);
+                system.assertEquals(vrsOriginal.Number_of_Volunteers__c, hr.Number_of_Volunteers__c);
+                system.assertEquals(vrsOriginal.Comments__c, hr.Comments__c);
+                system.assertEquals(vrsOriginal.Schedule_Start_Date_Time__c.Time(), hr.Planned_Start_Date_Time__c.Time());
+            }
+        }
+        
+    }
 }

--- a/src/classes/VOL_VRS_TEST.cls
+++ b/src/classes/VOL_VRS_TEST.cls
@@ -35,92 +35,161 @@ public with sharing class VOL_VRS_TEST {
     // Test Volunteer Recurrence Schedules
     public static testmethod void TestVRS() {
 
-		// create test data
+        // create test data
         Campaign cmp = new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, 
-        	name='Job Calendar Test Campaign', IsActive=true);
+            name='Job Calendar Test Campaign', IsActive=true);
         insert cmp;
         Volunteer_Job__c job = new Volunteer_Job__c(name='Job1', campaign__c=cmp.Id);
         insert job;
-		Contact contact = new Contact(firstname='test', lastname='test');
-		insert contact;
-		
-		Volunteer_Recurrence_Schedule__c vrs = new Volunteer_Recurrence_Schedule__c(
-			Contact__c = contact.Id, 
-			Volunteer_Job__c = job.Id,
-			Days_of_Week__c = 'Monday;Friday',
-			Duration__c = 1.5,
-			Number_of_Volunteers__c = 2,
-			Comments__c = 'my comments!',
-			Schedule_Start_Date_Time__c = date.newInstance(2012,2,1),
-			Schedule_End_Date__c = date.newInstance(2012,6,30),
-			Weekly_Occurrence__c = '1st');
-		insert vrs;
-		
-		system.assertEquals(true, VOL_VRS.alternateWeekVRS(vrs, date.newInstance(2012,2,1)));
-		system.assertEquals(true, VOL_VRS.alternateWeekVRS(vrs, date.newInstance(2012,2,4)));
-		system.assertEquals(false, VOL_VRS.alternateWeekVRS(vrs, date.newInstance(2012,2,6)));
-		system.assertEquals(false, VOL_VRS.alternateWeekVRS(vrs, date.newInstance(2012,2,11)));
-		system.assertEquals(true, VOL_VRS.alternateWeekVRS(vrs, date.newInstance(2012,2,13)));
-			
+        Contact contact = new Contact(firstname='test', lastname='test');
+        insert contact;
+        
+        Volunteer_Recurrence_Schedule__c vrs = new Volunteer_Recurrence_Schedule__c(
+            Contact__c = contact.Id, 
+            Volunteer_Job__c = job.Id,
+            Days_of_Week__c = 'Monday;Friday',
+            Duration__c = 1.5,
+            Number_of_Volunteers__c = 2,
+            Comments__c = 'my comments!',
+            Schedule_Start_Date_Time__c = date.newInstance(2012,2,1),
+            Schedule_End_Date__c = date.newInstance(2012,6,30),
+            Weekly_Occurrence__c = '1st');
+        insert vrs;
+        
+        system.assertEquals(true, VOL_VRS.alternateWeekVRS(vrs, date.newInstance(2012,2,1)));
+        system.assertEquals(true, VOL_VRS.alternateWeekVRS(vrs, date.newInstance(2012,2,4)));
+        system.assertEquals(false, VOL_VRS.alternateWeekVRS(vrs, date.newInstance(2012,2,6)));
+        system.assertEquals(false, VOL_VRS.alternateWeekVRS(vrs, date.newInstance(2012,2,11)));
+        system.assertEquals(true, VOL_VRS.alternateWeekVRS(vrs, date.newInstance(2012,2,13)));
+            
         Job_Recurrence_Schedule__c jrs = new Job_Recurrence_Schedule__c(Volunteer_Job__c = job.Id);
-		jrs.Days_of_Week__c = 'Monday;Wednesday;Friday';
-		jrs.Duration__c = 1;
-		jrs.Schedule_Start_Date_Time__c = date.newInstance(2012,1,1);
-		jrs.Schedule_End_Date__c = date.newInstance(2012,12,31);
-		jrs.Weekly_Occurrence__c = 'Every';
-		jrs.Desired_Number_of_Volunteers__c = 5;
-		Test.startTest();
-		insert jrs;
-		Test.stopTest(); 
-		
-		list<Volunteer_Shift__c> listShift = [select Id, Name, Volunteer_Job__r.Name from Volunteer_Shift__c where Job_Recurrence_Schedule__c = :jrs.Id];
-		system.debug(listShift);
-		system.assertEquals(157, listShift.size());
-		
-		list<Volunteer_Hours__c> listHours = [select Id, Status__c, Number_of_Volunteers__c, Comments__c 
-			from Volunteer_Hours__c where Volunteer_Recurrence_Schedule__c = :vrs.Id];
-		system.assertEquals(10, listHours.size());
-		system.assertEquals(vrs.Number_of_Volunteers__c, listHours[0].Number_of_Volunteers__c);
-		system.assertEquals(vrs.Comments__c, listHours[0].Comments__c);
-		
-		listHours[0].Status__c = 'Completed';
-		update listHours[0];
-		
-		vrs.Days_of_Week__c = 'Wednesday';
-		vrs.Weekly_Occurrence__c = 'Alternate';
-		update vrs;
-		
-		listHours = [select Id, Status__c from Volunteer_Hours__c where Volunteer_Recurrence_Schedule__c = :vrs.Id];
-		system.assertEquals(12, listHours.size());  // 11 new ones, plus the completed one saved.
-		
-		// remember those hours
-		set<ID> setHoursId = new set<ID>();
-		for (Volunteer_Hours__c hour : listHours) {
-			setHoursId.add(hour.Id);
-		}
-		
-		// test deleting the vrs to cleanup non committed hours
-		delete vrs;		
-		listHours = [select Id, Status__c from Volunteer_Hours__c where Id in :setHoursId];
-		system.assertEquals(1, listHours.size());
-		
-		// test deleting a Job will also delete the vrs's
-		vrs = new Volunteer_Recurrence_Schedule__c(
-			Contact__c = contact.Id, 
-			Volunteer_Job__c = job.Id,
-			Days_of_Week__c = 'Monday;Friday',
-			Duration__c = 1.5,
-			Schedule_Start_Date_Time__c = date.newInstance(2012, 2, 1),
-			Schedule_End_Date__c = date.newInstance(2012,6,30),
-			Weekly_Occurrence__c = '1st');
-		insert vrs;
-		
-		list<Volunteer_Recurrence_Schedule__c> listVRS = [select Id from Volunteer_Recurrence_Schedule__c where Volunteer_Job__c = :job.Id];
-		system.assertEquals(1, listVRS.size());
-		delete job;
-		listVRS = [select Id from Volunteer_Recurrence_Schedule__c where Id = :listVRS[0].Id];
-		system.assertEquals(0, listVRS.size());
-						
+        jrs.Days_of_Week__c = 'Monday;Wednesday;Friday';
+        jrs.Duration__c = 1;
+        jrs.Schedule_Start_Date_Time__c = date.newInstance(2012,1,1);
+        jrs.Schedule_End_Date__c = date.newInstance(2012,12,31);
+        jrs.Weekly_Occurrence__c = 'Every';
+        jrs.Desired_Number_of_Volunteers__c = 5;
+        Test.startTest();
+        insert jrs;
+        Test.stopTest(); 
+        
+        list<Volunteer_Shift__c> listShift = [select Id, Name, Volunteer_Job__r.Name from Volunteer_Shift__c where Job_Recurrence_Schedule__c = :jrs.Id];
+        system.debug(listShift);
+        system.assertEquals(157, listShift.size());
+        
+        list<Volunteer_Hours__c> listHours = [select Id, Status__c, Number_of_Volunteers__c, Comments__c 
+            from Volunteer_Hours__c where Volunteer_Recurrence_Schedule__c = :vrs.Id];
+        system.assertEquals(10, listHours.size());
+        system.assertEquals(vrs.Number_of_Volunteers__c, listHours[0].Number_of_Volunteers__c);
+        system.assertEquals(vrs.Comments__c, listHours[0].Comments__c);
+        
+        listHours[0].Status__c = 'Completed';
+        update listHours[0];
+        
+        vrs.Days_of_Week__c = 'Wednesday';
+        vrs.Weekly_Occurrence__c = 'Alternate';
+        update vrs;
+        
+        listHours = [select Id, Status__c from Volunteer_Hours__c where Volunteer_Recurrence_Schedule__c = :vrs.Id];
+        system.assertEquals(12, listHours.size());  // 11 new ones, plus the completed one saved.
+        
+        // remember those hours
+        set<ID> setHoursId = new set<ID>();
+        for (Volunteer_Hours__c hour : listHours) {
+            setHoursId.add(hour.Id);
+        }
+        
+        // test deleting the vrs to cleanup non committed hours
+        delete vrs;     
+        listHours = [select Id, Status__c from Volunteer_Hours__c where Id in :setHoursId];
+        system.assertEquals(1, listHours.size());
+        
+        // test deleting a Job will also delete the vrs's
+        vrs = new Volunteer_Recurrence_Schedule__c(
+            Contact__c = contact.Id, 
+            Volunteer_Job__c = job.Id,
+            Days_of_Week__c = 'Monday;Friday',
+            Duration__c = 1.5,
+            Schedule_Start_Date_Time__c = date.newInstance(2012, 2, 1),
+            Schedule_End_Date__c = date.newInstance(2012,6,30),
+            Weekly_Occurrence__c = '1st');
+        insert vrs;
+        
+        list<Volunteer_Recurrence_Schedule__c> listVRS = [select Id from Volunteer_Recurrence_Schedule__c where Volunteer_Job__c = :job.Id];
+        system.assertEquals(1, listVRS.size());
+        delete job;
+        listVRS = [select Id from Volunteer_Recurrence_Schedule__c where Id = :listVRS[0].Id];
+        system.assertEquals(0, listVRS.size());
+                        
     }
-	
+    
+    //******************************************************************************************************
+    // Test updating existing Volunteer Recurrence Schedules
+    public static testmethod void TestVRSUpdate() {
+
+        // create test data
+        Campaign cmp = new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, 
+            name='Job Calendar Test Campaign', IsActive=true);
+        insert cmp;
+        Volunteer_Job__c job = new Volunteer_Job__c(name='Job1', campaign__c=cmp.Id);
+        insert job;
+        Contact contact = new Contact(firstname='test', lastname='test');
+        insert contact;
+        
+        Volunteer_Recurrence_Schedule__c vrs = new Volunteer_Recurrence_Schedule__c(
+            Contact__c = contact.Id, 
+            Volunteer_Job__c = job.Id,
+            Volunteer_Hours_Status__c = 'My Custom Status',
+            Days_of_Week__c = 'Monday;Wednesday',
+            Duration__c = 1.5,
+            Number_of_Volunteers__c = 2,
+            Comments__c = 'my comments!',
+            Schedule_Start_Date_Time__c = date.newInstance(2016,11,1),
+            Schedule_End_Date__c = date.newInstance(2016,12,31),
+            Weekly_Occurrence__c = '2nd');
+        insert vrs;
+        
+        Job_Recurrence_Schedule__c jrs = new Job_Recurrence_Schedule__c(Volunteer_Job__c = job.Id);
+        jrs.Days_of_Week__c = 'Monday;Wednesday;Friday';
+        jrs.Duration__c = 1;
+        jrs.Schedule_Start_Date_Time__c = date.newInstance(2016,11,1);
+        jrs.Schedule_End_Date__c = date.newInstance(2016,12,31);
+        jrs.Weekly_Occurrence__c = '2nd';
+        jrs.Desired_Number_of_Volunteers__c = 5;
+        Test.startTest();
+        insert jrs;
+        Test.stopTest(); 
+        
+        list<Volunteer_Shift__c> listShift = [select Id, Name, Volunteer_Job__r.Name from Volunteer_Shift__c where Job_Recurrence_Schedule__c = :jrs.Id];
+        system.debug(listShift);
+        system.assertEquals(6, listShift.size());
+        
+        list<Volunteer_Hours__c> listHours = [select Id, Status__c, Number_of_Volunteers__c, Comments__c 
+            from Volunteer_Hours__c where Volunteer_Recurrence_Schedule__c = :vrs.Id order by Planned_Start_Date_Time__c];
+        system.assertEquals(4, listHours.size());
+        system.assertEquals(vrs.Number_of_Volunteers__c, listHours[0].Number_of_Volunteers__c);
+        system.assertEquals(vrs.Comments__c, listHours[0].Comments__c);
+        
+        listHours[0].Status__c = 'No-Show';
+        system.debug('****DJH updating hr: '+ listHours[0]); 
+        update listHours[0];
+        
+        vrs.Days_of_Week__c = 'Monday;Friday';
+        vrs.Volunteer_Hours_Status__c = 'Confirmed';
+        update vrs;
+
+        listHours = [select Id, Status__c, Planned_Start_Date_Time__c from Volunteer_Hours__c where Volunteer_Recurrence_Schedule__c = :vrs.Id order by Planned_Start_Date_Time__c];
+		system.debug('****DJH listHours: ' + listHours);
+        
+        listHours = [select Id, Status__c from Volunteer_Hours__c where Status__c = 'My Custom Status' and Volunteer_Recurrence_Schedule__c = :vrs.Id];
+        system.assertEquals(1, listHours.size());  // first Monday was changed to no-show
+        
+        listHours = [select Id, Status__c from Volunteer_Hours__c where Status__c = 'No-Show' and Volunteer_Recurrence_Schedule__c = :vrs.Id];
+        system.assertEquals(1, listHours.size());  
+
+        listHours = [select Id, Status__c from Volunteer_Hours__c where Status__c = 'Confirmed' and Volunteer_Recurrence_Schedule__c = :vrs.Id];
+        system.assertEquals(2, listHours.size());  
+        
+    }
+    
 }

--- a/src/triggers/VOL_VRS_MaintainHours.trigger
+++ b/src/triggers/VOL_VRS_MaintainHours.trigger
@@ -31,7 +31,7 @@
 trigger VOL_VRS_MaintainHours on Volunteer_Recurrence_Schedule__c (after insert, after undelete, after update, before delete) {
 
     if (trigger.isInsert || trigger.isUpdate || trigger.isUnDelete) {
-        VOL_VRS.ProcessListVRS(trigger.new);  
+        VOL_VRS.ProcessListVRS(trigger.new, true);  
     }
 
     if (trigger.isDelete) {

--- a/src/triggers/VOL_VRS_MaintainHours.trigger
+++ b/src/triggers/VOL_VRS_MaintainHours.trigger
@@ -31,7 +31,7 @@
 trigger VOL_VRS_MaintainHours on Volunteer_Recurrence_Schedule__c (after insert, after undelete, after update, before delete) {
 
     if (trigger.isInsert || trigger.isUpdate || trigger.isUnDelete) {
-        VOL_VRS.ProcessListVRS(trigger.new, true);  
+        VOL_VRS.ProcessListVRS(trigger.new, trigger.old, true);
     }
 
     if (trigger.isDelete) {


### PR DESCRIPTION
# Critical Changes

# Changes

- The scheduler has been optimized to only evaluate future Volunteer Shifts when processing Job Recurrence Schedules and Volunteer Recurrence Schedules, rather than also evaluating past Volunteer Shifts.

- The scheduler will now reuse existing Volunteer Hours when processing Job Recurrence Schedules and Volunteer Recurrence Schedules.  For Volunteer Hours that already exist on past Volunteer Shifts, the Volunteer Hours will be left alone and no fields, including Status, will be changed.  For existing Volunteer Hours on future Volunteer Shifts, fields will be updated as specified in the Volunteer Recurrence Schedule.

# Issues Closed
Fixes #154 
Fixes #208 
