### PR TITLE
Getting Volunteer Roster report to work under LEX.  Issue #206

### DIFF
--- a/src/classes/VOL_CTRL_OpenReport.cls
+++ b/src/classes/VOL_CTRL_OpenReport.cls
@@ -44,7 +44,7 @@ public with sharing class VOL_CTRL_OpenReport {
 		if (strDevName == null || strDevName == '') {
 			return null;
 		}
-				
+
 		//redirect to newly created opp in edit mode
 		ID reportId = reportIdFromDevName(strDevName);
 		if (reportId != null) {
@@ -55,8 +55,15 @@ public with sharing class VOL_CTRL_OpenReport {
 			} else {
 				strParams = '';
 			}
-			PageReference page = new PageReference('/' + reportId + strParams);
-        	page.setRedirect(true);
+			PageReference page;
+            // see if we are in Lightning Experience vs Aloha/Salesforce Classic
+			if (UserInfo.getUiThemeDisplayed() != 'Theme4d') {
+			    page = new PageReference('/' + reportId + strParams);
+			} else {
+			    strParams = strParams.replace('pv', 'fv');
+                page = new PageReference('/one/one.app#/sObject/' + reportId + '/view' + strParams );
+			}
+            page.setRedirect(true);
         	return page;
 		} 
 		


### PR DESCRIPTION
This fixes the way our Volunteer Roster buttons open up the report under LEX.  In order to test under unmanaged code you must edit the Volunteer Job, Volunteer Shift, and Campaign "Volunteer Roster" buttons to change their URL from 
/apex/GW_Volunteers__OpenReport?ReportDevName=Volunteer_Roster..... to 
/apex/OpenReport?ReportDevName=Volunteer_Roster.....

Ie, remove the namespace prefix.  Under classic, you can just fixup the namespace in the address bar to 'c', but under LEX, no such luck!

Currently this solution will cause an alert from Salesforce about opening a new tab.  Farhan Tahir says it is a bug in core, and I will be opening an investigation.  Here is the org62 post: https://org62.lightning.force.com/one/one.app#eyJjb21wb25lbnREZWYiOiJmb3JjZUNoYXR0ZXI6ZGVza3RvcENoYXR0ZXIiLCJhdHRyaWJ1dGVzIjp7InZhbHVlcyI6eyJmZWVkRWxlbWVudElkIjoiMEQ1ME0wMDAwMzVRNDZuIn19LCJhOnQiOjE0OTAyMTMxNTY1NTF9

Even if core never fixes this issue, the new behavior is better than what we have today, which is that the report is NOT filtered under LEX, making it worthless!

# Critical Changes

# Changes

# Issues Closed
Fixed #206 
