### PR TITLE
correctly handle timezone issues and GMT in SOQL

### DIFF
--- a/src/classes/VOL_CTRL_JobCalendar_TEST.cls
+++ b/src/classes/VOL_CTRL_JobCalendar_TEST.cls
@@ -87,4 +87,47 @@ private with sharing class VOL_CTRL_JobCalendar_TEST {
 		listS = VOL_CTRL_JobCalendar.getListShiftsWeb2(cmpIdGrandparent, '*', '2010-01-01 1:1:1', '2050-01-01 1:1:1', false, true);
 		system.assertEquals(mapCmp.size(), listS.size()); 
     }
+
+    /*******************************************************************************************************
+    * @description test timezone handling for Shifts under LA timezone
+    * @return void
+    */
+    private static testMethod void testTimeZoneHandlingFromLA() {
+        testTimeZoneHandling('America/Los_Angeles');
+    }
+
+    /*******************************************************************************************************
+    * @description test timezone handling for Shifts under Sydney timezone
+    * @return void
+    */
+    private static testMethod void testTimeZoneHandlingFromSydney() {
+        testTimeZoneHandling('Australia/Sydney');
+    }
+
+    /*******************************************************************************************************
+    * @description test timezone handling for Shifts
+    * @param timezone what timezone to run under while creating and querying shifts
+    * @return void
+    */
+    private static void testTimeZoneHandling(String timezone) {
+
+        String uniqueUserName = 'admin' + DateTime.now().getTime() + '@testorg.com';
+        Profile p = [SELECT Id FROM Profile WHERE Name='System Administrator'];
+        User u = new User(Alias = 'admin', Email='admin@testorg.com',
+            EmailEncodingKey='UTF-8', LastName='Testing', LanguageLocaleKey='en_US',
+            LocaleSidKey='en_US', ProfileId = p.Id,
+            TimeZoneSidKey=timezone,
+            UserName=uniqueUserName);
+
+        system.runAs(u) {
+            VOL_SharedCode_TEST.setupTimeZoneTestData();
+
+            list<Volunteer_Shift__c> listS = VOL_CTRL_JobCalendar.getListShiftsWeb('*', '*',
+                datetime.newInstanceGMT(system.Today(), time.newInstance(0,0,0,0)).format('yyyy-MM-dd hh:mm:ss'),
+                datetime.newInstanceGMT(system.Today(), time.newInstance(23,59,59,0)).format('yyyy-MM-dd hh:mm:ss'),
+                false);
+            system.assertEquals(24, listS.size(), 'we should get exactly one days worth of shifts, regardless of timezone');
+        }
+    }
+
 }

--- a/src/classes/VOL_CTRL_PersonalSiteContactInfo.cls
+++ b/src/classes/VOL_CTRL_PersonalSiteContactInfo.cls
@@ -213,9 +213,10 @@ global with sharing class VOL_CTRL_PersonalSiteContactInfo {
                         strSoql += strComma + strF;
                         strComma = ', ';
                     }
+                    DateTime dtToday = datetime.newInstance(system.today(), time.newInstance(0, 0, 0, 0));
                     strSoql += ' from Volunteer_Hours__c where Contact__c = :contactId ';
                     strSoql += ' and Status__c <> \'Canceled\' and Status__c <>  \'Completed\' ';
-                    strSoql += ' and Shift_Start_Date_Time__c >= YESTERDAY ';
+                    strSoql += ' and Shift_Start_Date_Time__c >= :dtToday ';
                     strSoql += ' order by Shift_Start_Date_Time__c ASC ';        
                     strSoql += ' limit ' + cRowsUpcoming;
                     listUpcomingVolunteerHours = Database.Query(strSoql);                

--- a/src/classes/VOL_CTRL_PersonalSiteContactInfo.cls
+++ b/src/classes/VOL_CTRL_PersonalSiteContactInfo.cls
@@ -215,8 +215,7 @@ global with sharing class VOL_CTRL_PersonalSiteContactInfo {
                     }
                     strSoql += ' from Volunteer_Hours__c where Contact__c = :contactId ';
                     strSoql += ' and Status__c <> \'Canceled\' and Status__c <>  \'Completed\' ';
-                    Date dtToday = system.today();
-                    strSoql += ' and Shift_Start_Date_Time__c >= :dtToday ';
+                    strSoql += ' and Shift_Start_Date_Time__c >= YESTERDAY ';
                     strSoql += ' order by Shift_Start_Date_Time__c ASC ';        
                     strSoql += ' limit ' + cRowsUpcoming;
                     listUpcomingVolunteerHours = Database.Query(strSoql);                

--- a/src/classes/VOL_CTRL_PersonalSiteContactInfo_TEST.cls
+++ b/src/classes/VOL_CTRL_PersonalSiteContactInfo_TEST.cls
@@ -144,5 +144,53 @@ private with sharing class VOL_CTRL_PersonalSiteContactInfo_TEST {
         system.assertEquals('TestIsNowTesty', con.LastName);
 
     }
-    
+
+    /*******************************************************************************************************
+    * @description test timezone handling for Shifts under LA timezone
+    * @return void
+    */
+    private static testMethod void testTimeZoneHandlingFromLA() {
+        testTimeZoneHandling('America/Los_Angeles');
+    }
+
+    /*******************************************************************************************************
+    * @description test timezone handling for Shifts under Sydney timezone
+    * @return void
+    */
+    private static testMethod void testTimeZoneHandlingFromSydney() {
+        testTimeZoneHandling('Australia/Sydney');
+    }
+
+    /*******************************************************************************************************
+    * @description test timezone handling for Shifts
+    * @param timezone what timezone to run under while creating and querying shifts
+    * @return void
+    */
+    private static void testTimeZoneHandling(String timezone) {
+
+        String uniqueUserName = 'admin' + DateTime.now().getTime() + '@testorg.com';
+        Profile p = [SELECT Id FROM Profile WHERE Name='System Administrator'];
+        User u = new User(Alias = 'admin', Email='admin@testorg.com',
+            EmailEncodingKey='UTF-8', LastName='Testing', LanguageLocaleKey='en_US',
+            LocaleSidKey='en_US', ProfileId = p.Id,
+            TimeZoneSidKey=timezone,
+            UserName=uniqueUserName);
+
+        system.runAs(u) {
+            Id conId = VOL_SharedCode_TEST.setupTimeZoneTestData();
+
+            // setup page
+            PageReference pageRef = Page.PersonalSiteContactInfo;
+            pageRef.getParameters().put('contactId', conId);
+            Test.setCurrentPage(pageRef);
+
+            //instantiate the controller
+            VOL_CTRL_PersonalSiteContactInfo ctrl = new VOL_CTRL_PersonalSiteContactInfo();
+            System.AssertEquals(conId, ctrl.contactId);
+            ctrl.cRowsUpcoming = 100;
+            System.AssertEquals(0, ctrl.listCompletedVolunteerHours.size());
+            System.AssertEquals(48, ctrl.listUpcomingVolunteerHours.size(), 'we should always get back today and tomorrow shifts');
+        }
+    }
+
 }

--- a/src/classes/VOL_CTRL_VolunteersJobListingFS_TEST.cls
+++ b/src/classes/VOL_CTRL_VolunteersJobListingFS_TEST.cls
@@ -206,4 +206,49 @@ private with sharing class VOL_CTRL_VolunteersJobListingFS_TEST {
 		system.assertEquals(mapCmp.size(), ctrl2.listVolunteerJobs.size()); 
     }
 
+    /*******************************************************************************************************
+    * @description test timezone handling for Shifts under LA timezone
+    * @return void
+    */
+    private static testMethod void testTimeZoneHandlingFromLA() {
+        testTimeZoneHandling('America/Los_Angeles');
+    }
+
+    /*******************************************************************************************************
+    * @description test timezone handling for Shifts under Sydney timezone
+    * @return void
+    */
+    private static testMethod void testTimeZoneHandlingFromSydney() {
+        testTimeZoneHandling('Australia/Sydney');
+    }
+
+    /*******************************************************************************************************
+    * @description test timezone handling for Shifts
+    * @param timezone what timezone to run under while creating and querying shifts
+    * @return void
+    */
+    private static void testTimeZoneHandling(String timezone) {
+
+        String uniqueUserName = 'admin' + DateTime.now().getTime() + '@testorg.com';
+        Profile p = [SELECT Id FROM Profile WHERE Name='System Administrator'];
+        User u = new User(Alias = 'admin', Email='admin@testorg.com',
+            EmailEncodingKey='UTF-8', LastName='Testing', LanguageLocaleKey='en_US',
+            LocaleSidKey='en_US', ProfileId = p.Id,
+            TimeZoneSidKey=timezone,
+            UserName=uniqueUserName);
+
+        system.runAs(u) {
+            VOL_SharedCode_TEST.setupTimeZoneTestData();
+
+            PageReference pageRef = Page.VolunteersJobListingFS;
+            Test.setCurrentPage(pageRef);
+
+            //instantiate the controller
+            VOL_CTRL_VolunteersJobListingFS ctrl = new VOL_CTRL_VolunteersJobListingFS();
+            System.AssertEquals(1, ctrl.listVolunteerJobs.size());
+            Volunteer_Job__c job = ctrl.listVolunteerJobs[0];
+            System.assertEquals(48, job.Volunteer_Job_Slots__r.size(), 'we should always get today and tomorrow shifts');
+        }
+    }
+
 }

--- a/src/classes/VOL_SharedCode_TEST.cls
+++ b/src/classes/VOL_SharedCode_TEST.cls
@@ -270,4 +270,52 @@ public with sharing class VOL_SharedCode_TEST {
         system.assertEquals(false, VOL_SharedCode.isOtherAddressField('otherphone'));
 
     }
+
+    /*******************************************************************************************************
+    * @description create a campaign, job, hourly shifts for yesterday, today, and tomorrow, then create
+    * a contact and assign Hours for each shift.
+    * @return Id the created Contact's Id
+    */
+    public static Id setupTimeZoneTestData() {
+
+        Campaign cmp = new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign,
+            name='timeZoneCampaign', IsActive=true);
+        insert cmp;
+
+        Volunteer_Job__c job = new Volunteer_Job__c(name='timeZoneJob', campaign__c=cmp.Id, Display_On_Website__c=true);
+        insert job;
+
+        List<Volunteer_Shift__c> listShift = new List<Volunteer_Shift__c>();
+        for (Integer iDay = -1; iDay < 2; iDay++) {
+            Date d = system.Today().addDays(iDay);
+            for (Integer i = 0; i < 24; i++) {
+                Volunteer_Shift__c shift = new Volunteer_Shift__c();
+                shift.Volunteer_Job__c = job.Id;
+                shift.Duration__c = 1;
+                shift.Desired_Number_of_Volunteers__c = 4;
+                shift.Start_Date_Time__c = dateTime.newInstance(d, time.newInstance(i, 0,0,0));
+                listShift.add(shift);
+            }
+        }
+        insert listShift;
+
+        Contact contact = new Contact(firstname='timezone', lastname='test');
+        insert contact;
+
+        List<Volunteer_Hours__c> listHours = new List<Volunteer_Hours__c>();
+        for (Volunteer_Shift__c shift : listShift) {
+            Volunteer_Hours__c hour = new Volunteer_Hours__c();
+            hour.Volunteer_Job__c = shift.Volunteer_Job__c;
+            hour.Volunteer_Shift__c = shift.Id;
+            hour.Contact__c = contact.Id;
+            hour.Status__c = 'Confirmed';
+            hour.Start_Date__c = shift.Start_Date_Time__c.date();
+            listHours.add(hour);
+        }
+        insert listHours;
+
+        return contact.Id;
+    }
+
+
 }


### PR DESCRIPTION
make sure pages display full days worth of shifts using the time zone.  I verified and wrote tests to ensure the JobCalendar, and JobListingFS pages give you the full days worth of shifts, regardless of your time zone.  The JobListingFS page does include shifts that have passed for the current hour, but are on that day, but I don't believe we should change that behavior.  No customers have complained, and I'm concerned that changing it will disrupt some groups that might actually want someone to register late, or do the registration online after they've finished the shift.  

The PersonalSiteContactInfo page did have a real bug, however, that is now fixed so that it to will display all the upcoming shifts starting with today, rather than dependent on the time you look at it, or the timezone you are in.  This fixes a customer issue where some of their GMT+11 shifts weren't showing up because they were actually in the previous day GMT.

I will post you a snippet of code you can use to create hourly shifts and hours for yesterday, today, and tomorrow to make testing this out easier.

# Critical Changes

# Changes

# Issues Closed
Fixed #345

# New Metadata

# Deleted Metadata
