### PR TITLE
Fix XSS issue on VolunteersJobListingFS page

### DIFF
--- a/src/pages/VolunteersJobListingFS.page
+++ b/src/pages/VolunteersJobListingFS.page
@@ -176,7 +176,13 @@
         </apex:outputPanel>
         
         <apex:outputPanel id="panelExternalJob" rendered="{!job.External_Signup_Url__c != null && NOT(jobAllShiftsInThePast)}" >
-            <apex:outputLink target="_blank" styleClass="externalJobLink" value="{!job.External_Signup_Url__c}" >{!$Label.labelExternalSignupUrl}</apex:outputLink>
+            <apex:outputLink
+                target="_blank"
+                styleClass="externalJobLink"
+                rendered="{!NOT(BEGINS(LOWER(job.External_Signup_Url__c), 'javascript:'))}"
+                value="{!job.External_Signup_Url__c}">
+                {!$Label.labelExternalSignupUrl}
+            </apex:outputLink>
             <br/><br/>
         </apex:outputPanel>
 


### PR DESCRIPTION
# Critical Changes

# Changes
If External_Signup_Url__c is a javascript action (e.g. `javascript:alert()`), the link will not be rendered on the page.

# Issues Closed
Fixes XSS issues on VolunteersJobListingFS due to External_Signup_Url__c valued used in link

# New Metadata

# Deleted Metadata
