### PR TITLE
labelShiftNumbers: replaced HTML with ' - ' + translations

### DIFF
--- a/push/orgs_qa.txt
+++ b/push/orgs_qa.txt
@@ -1,2 +1,3 @@
 00D3F000000DDCI  mrbelvedere@npspreleasetest.org.prerelease
 00D41000001Ncgw
+00Di0000000HVnY

--- a/src/labels/CustomLabels.labels
+++ b/src/labels/CustomLabels.labels
@@ -1077,7 +1077,7 @@ day:      &apos;day&apos;</value>
         <language>en_US</language>
         <protected>false</protected>
         <shortDescription>labelShiftNumbers</shortDescription>
-        <value>confirmed: {0}&amp;nbsp;&amp;nbsp;available: {1}</value>
+        <value>confirmed: {0} - available: {1}</value>
     </labels>
     <labels>
         <fullName>labelShowHelp</fullName>

--- a/src/pages/JobCalendar.page
+++ b/src/pages/JobCalendar.page
@@ -155,7 +155,7 @@
                                     strUrl = '{!$Site.CurrentSiteUrl + IF(fPersonalSite, ns+'PersonalSiteJobListing', ns+'VolunteersJobListingFS')}' +
                                         '?Calendar=1&volunteerShiftId=' + strShiftId + '&jobId=' + strJobId +
                                         '&dtMonthFilter=' + strApexDateUTC(dtStart) +
-                                        '{!JSINHTMLENCODE(IF(strParams != null, '&' + strParams, ''))}';
+                                        '{!JSENCODE(IF(strParams != null, '&' + strParams, ''))}';
                                 } else if ({!NOT(fPrint)}) {
                                     strUrl = '/' + strShiftId;
                                 }                                

--- a/src/translations/de.translation
+++ b/src/translations/de.translation
@@ -528,7 +528,7 @@ day:      &apos;Tag&apos;</label>
         <name>labelShiftClosed</name>
     </customLabels>
     <customLabels>
-        <label>Bestätigt: {0}&amp;nbsp;&amp;nbsp;verfügbar: {1}</label>
+        <label>Bestätigt: {0} - verfügbar: {1}</label>
         <name>labelShiftNumbers</name>
     </customLabels>
     <customLabels>

--- a/src/translations/fr.translation
+++ b/src/translations/fr.translation
@@ -528,7 +528,7 @@ day: &apos;jour&apos;</label>
         <name>labelShiftClosed</name>
     </customLabels>
     <customLabels>
-        <label>confirmé : {0}&amp;Nbsp;&amp;nbsp;disponible(s) : {1}</label>
+        <label>confirmé : {0} - disponible(s) : {1}</label>
         <name>labelShiftNumbers</name>
     </customLabels>
     <customLabels>

--- a/src/translations/iw.translation
+++ b/src/translations/iw.translation
@@ -528,7 +528,7 @@ day: &apos;ום&apos;</label>
         <name>labelShiftClosed</name>
     </customLabels>
     <customLabels>
-        <label>מאושר: {0}&amp;nbsp;&amp;nbsp;זמין: {1}</label>
+        <label>מאושר: {0} - זמין: {1}</label>
         <name>labelShiftNumbers</name>
     </customLabels>
     <customLabels>

--- a/src/translations/ja.translation
+++ b/src/translations/ja.translation
@@ -528,7 +528,7 @@ day:      &apos;日&apos;</label>
         <name>labelShiftClosed</name>
     </customLabels>
     <customLabels>
-        <label>確認済み: {0}&amp;nbsp;&amp;nbsp;利用可: {1}</label>
+        <label>確認済み: {0} - 利用可: {1}</label>
         <name>labelShiftNumbers</name>
     </customLabels>
     <customLabels>


### PR DESCRIPTION
Replaced `&nbsp;&nbsp;` with ` - ` in **labelShiftNumbers** (English) + translations:
- German
- French
- Hebrew
- Japanese


**labelShiftNumbers** used in Shift entries in **Shift Calendar**:

- Month: hover over label
- Week: Shift Card + hover over label
- Day: Shift Card + hover over label

# Critical Changes

# Changes
Fixed use of HTML in **Shift Calendar **

# Issues Closed

# New Metadata

# Deleted Metadata
