### PR TITLE
Contact matching rules in settings now ignores case

### DIFF
--- a/src/classes/VOL_SharedCode.cls
+++ b/src/classes/VOL_SharedCode.cls
@@ -388,7 +388,7 @@ global with sharing class VOL_SharedCode {
 
     // global code to lookup an existing contact
     // listStrFields are optional fields to include in the soql call
-    global static list<Contact> LookupContact(Contact contact, list<string> listStrFields) {
+    global static list<Contact> LookupContact(Contact contactRecord, list<string> listStrFields) {
         // let's see if we can find any matching Contacts.
         // we need to use dynamic soql, since we allow the user to modify the FieldSet of fields to edit.
         string strSoql = 'select ';
@@ -411,11 +411,11 @@ global with sharing class VOL_SharedCode {
 
         final String rule = VolunteersSettings.Contact_Matching_Rule__c;
         if (rule.containsIgnoreCase(String.valueOf(Contact.LastName))) {
-            strSoql += strAnd + ' (Lastname=\'' + StrEscape(contact.Lastname) + '\') ';
+            strSoql += strAnd + ' (Lastname=\'' + StrEscape(contactRecord.LastName) + '\') ';
             strAnd = ' and ';
         }
         if (rule.containsIgnoreCase(String.valueOf(Contact.FirstName))) {
-            strSoql += strAnd + ' (Firstname=\'' + StrEscape(contact.Firstname) + '\'';
+            strSoql += strAnd + ' (Firstname=\'' + StrEscape(contactRecord.FirstName) + '\'';
             strAnd = ' and ';
 
             // any additional firstname fields to check
@@ -423,27 +423,27 @@ global with sharing class VOL_SharedCode {
                 list<string> listStrFname = new list<string>();
                 listStrFname = VolunteersSettings.Contact_Match_First_Name_Fields__c.split(';');
                 for (string str : listStrFname) {
-                    strSoql += ' or ' + str + '=\'' + StrEscape(contact.Firstname) + '\'';
+                    strSoql += ' or ' + str + '=\'' + StrEscape(contactRecord.FirstName) + '\'';
                 }
             }
             strSoql += ') ';
         }
         if (rule.containsIgnoreCase(String.valueOf(Contact.Email))) {
-            strSoql += strAnd + ' (Email=\'' + contact.Email + '\'';
+            strSoql += strAnd + ' (Email=\'' + contactRecord.Email + '\'';
             strAnd = ' and ';
             // any additional email fields to check
             if (VolunteersSettings.Contact_Match_Email_Fields__c != null) {
                 list<string> listStrEmail = new list<string>();
                 listStrEmail = VolunteersSettings.Contact_Match_Email_Fields__c.split(';');
                 for (string str : listStrEmail) {
-                    strSoql += ' or ' + str + '=\'' + contact.Email + '\'';
+                    strSoql += ' or ' + str + '=\'' + contactRecord.Email + '\'';
                 }
             }
             // handle NPSP email fields
             if (IsNPSPInstalled) {
-                strSoql += ' or npe01__AlternateEmail__c=\'' + contact.Email + '\'';
-                strSoql += ' or npe01__HomeEmail__c=\'' + contact.Email + '\'';
-                strSoql += ' or npe01__WorkEmail__c=\'' + contact.Email + '\'';
+                strSoql += ' or npe01__AlternateEmail__c=\'' + contactRecord.Email + '\'';
+                strSoql += ' or npe01__HomeEmail__c=\'' + contactRecord.Email + '\'';
+                strSoql += ' or npe01__WorkEmail__c=\'' + contactRecord.Email + '\'';
             }
             strSoql += ') ';
         }

--- a/src/classes/VOL_SharedCode.cls
+++ b/src/classes/VOL_SharedCode.cls
@@ -1,10 +1,10 @@
 /*
     Copyright (c) 2016, Salesforce.org
     All rights reserved.
-    
+
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
-    
+
     * Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above copyright
@@ -13,32 +13,32 @@
     * Neither the name of Salesforce.org nor the names of
       its contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
- 
+
     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
     POSSIBILITY OF SUCH DAMAGE.
 */
 
-global with sharing class VOL_SharedCode { 
+global with sharing class VOL_SharedCode {
 
     // the list of Campaigns that have Volunteer Jobs
     global list<SelectOption> listSOCampaignsWithJobs {
         get {
             list<SelectOption> listSO = new list<SelectOption>();
             listSO.add(new SelectOption('', ''));
-            for (Campaign c : [select Name, Id, StartDate from Campaign where RecordTypeId = :recordtypeIdVolunteersCampaign 
+            for (Campaign c : [select Name, Id, StartDate from Campaign where RecordTypeId = :recordtypeIdVolunteersCampaign
                 and IsActive = true order by StartDate desc, Name asc limit 999]) {
                 listSO.add(new SelectOption(c.id, c.name));
-            }       
+            }
             return listSO;
         }
     }
@@ -49,7 +49,7 @@ global with sharing class VOL_SharedCode {
         listSO.add(new SelectOption('', ''));
         for (Volunteer_Job__c vj : [select Name, Id from Volunteer_Job__c where Campaign__c = :campaignId order by name limit 999]) {
             listSO.add(new SelectOption(vj.id, vj.name));
-        }       
+        }
         return listSO;
     }
 
@@ -57,57 +57,57 @@ global with sharing class VOL_SharedCode {
     global list<SelectOption> listSOVolunteerShiftsOfVolunteerJobId(ID volunteerJobId, Date dtStart, Date dtEnd, boolean fIncludeShiftName, boolean fIncludeNumberNeeded) {
         return listSOVolunteerShiftsOfVolunteerJobIdFormat(volunteerJobId, dtStart, dtEnd, fIncludeShiftName, fIncludeNumberNeeded, null, null);
     }
-     
+
     // list of select options of Shifts for the specified job, using the date & time format strings for the shifts
-    public static list<SelectOption> listSOVolunteerShiftsOfVolunteerJobIdFormat(ID volunteerJobId, Date dtStart, Date dtEnd, 
+    public static list<SelectOption> listSOVolunteerShiftsOfVolunteerJobIdFormat(ID volunteerJobId, Date dtStart, Date dtEnd,
             boolean fIncludeShiftName, boolean fIncludeNumberNeeded, string strDateFormat, string strTimeFormat) {
-        
+
         list<Volunteer_Job__c> listVolunteerJobs = new List<Volunteer_Job__c>();
-        
+
         list<SelectOption> listSO = new list<SelectOption>();
         listSO.add(new SelectOption('', ''));
-        
+
         // ensure valid date ranges
         if (dtStart == null)
             dtStart = system.today();
         if (dtEnd == null)
             dtEnd = system.today().addMonths(12);
         dtEnd = dtEnd.addDays(1);
-           
+
         // get our shifts in a Job query, so we can use our common date/time formatting routine.
         listVolunteerJobs = [select Id, Campaign__r.IsActive, Campaign__r.Volunteer_Website_Time_Zone__c,
             Volunteer_Website_Time_Zone__c,
             (Select Id, Name, Start_Date_Time__c, Duration__c, Number_of_Volunteers_Still_Needed__c,
-                Description__c, System_Note__c From Volunteer_Job_Slots__r 
+                Description__c, System_Note__c From Volunteer_Job_Slots__r
                 where Start_Date_Time__c >= :dtStart and Start_Date_Time__c < :dtEnd
-                order by Start_Date_Time__c LIMIT 999) 
+                order by Start_Date_Time__c LIMIT 999)
             from Volunteer_Job__c where Id = :volunteerJobId];
-                
+
         // bail out if no jobs found
         if (listVolunteerJobs.size() == 0)
             return listSO;
-        
+
         // whether to use our datetime formatting, or salesforce default for the current user
-        boolean useDateTimeFixup = (strDateFormat != null && strTimeFormat != null);        
-        
+        boolean useDateTimeFixup = (strDateFormat != null && strTimeFormat != null);
+
         // put correct date/time format with appropriate timezone in system note field (in memory only)
         if (useDateTimeFixup)
             dateTimeFixup(listVolunteerJobs, strDateFormat, strTimeFormat);
-        
+
         for (Volunteer_Shift__c vs : listVolunteerJobs[0].Volunteer_Job_Slots__r) {
-            SelectOption so = new SelectOption(vs.id, 
-                (useDateTimeFixup ? vs.System_Note__c : vs.Start_Date_Time__c.format()) + 
+            SelectOption so = new SelectOption(vs.id,
+                (useDateTimeFixup ? vs.System_Note__c : vs.Start_Date_Time__c.format()) +
                 (fIncludeShiftName ? '&nbsp;&nbsp;&nbsp;&nbsp;(' + vs.name + ')' : '' ) +
-                (fIncludeNumberNeeded ? '&nbsp;&nbsp;' + 
-                    (vs.Number_of_Volunteers_Still_Needed__c > 0 ? 
+                (fIncludeNumberNeeded ? '&nbsp;&nbsp;' +
+                    (vs.Number_of_Volunteers_Still_Needed__c > 0 ?
                         system.label.labelCalendarStillNeeded + vs.Number_of_Volunteers_Still_Needed__c : system.label.labelCalendarShiftFull) +
                     ' ' : '' ));
-            so.setEscapeItem(false); 
+            so.setEscapeItem(false);
             listSO.add(so);
-        }       
-        return listSO;       
+        }
+        return listSO;
     }
-    
+
     // routine to go through all the shifts, and create the display string
     // for the shifts start date & time - end date & time, using the appropriate
     // time zone that might be specified on the Job, Campaign, or Site Guest User.
@@ -115,47 +115,47 @@ global with sharing class VOL_SharedCode {
     public static void dateTimeFixup(list<Volunteer_Job__c> listJob, string strDateFormat, string strTimeFormat) {
         // get default time zone for site guest user
         User u = [Select TimeZoneSidKey From User where id =: Userinfo.getUserId()];
-        
+
         // javascript formatting used 'tt' for am/pm, whereas apex formatting uses 'a'.
         string strFormat = strDateFormat + ' ' + strTimeFormat.replace('tt','a');
         string strFormatEndTime = strTimeFormat.replace('tt','a');
-        
+
         for (Volunteer_Job__c job : listJob) {
             string strTimeZone = job.Volunteer_Website_Time_Zone__c;
             if (strTimeZone == null) strTimeZone = job.Campaign__r.Volunteer_Website_Time_Zone__c;
             if (strTimeZone == null) strTimeZone = u.TimeZoneSidKey;
 
             for (Volunteer_Shift__c shift : job.Volunteer_Job_Slots__r) {
-                
+
                 DateTime dtEnd = shift.Start_Date_Time__c.addMinutes(integer.valueOf(shift.Duration__c * 60));
                 string strStart = shift.Start_Date_Time__c.format(strFormat, strTimeZone);
-                
+
                 // see if start and end are on the same day
                 if (shift.Start_Date_Time__c.format('d', strTimeZone) == dtEnd.format('d', strTimeZone)) {
-                    shift.System_Note__c =  strStart + ' - ' + dtEnd.format(strFormatEndTime, strTimeZone); 
+                    shift.System_Note__c =  strStart + ' - ' + dtEnd.format(strFormatEndTime, strTimeZone);
                 } else {
-                    shift.System_Note__c =  strStart + ' - ' + dtEnd.format(strFormat, strTimeZone);                        
-                }               
+                    shift.System_Note__c =  strStart + ' - ' + dtEnd.format(strFormat, strTimeZone);
+                }
             }
         }
     }
-    
+
     // return the GMT datetime for a datetime in the specified timezone
     public static DateTime dtGmtFromDtTimeZone(DateTime dt, TimeZone tz) {
         integer offset = tz.getOffset(dt);
         return dt.addSeconds(-offset / 1000);
     }
-    
+
     // Volunteer Custom Settings object.  Loads an existing, and if not found creates one with default values.
     global static Volunteers_Settings__c VolunteersSettings {
         get {
             if (VolunteersSettings == null) {
-                VolunteersSettings = Volunteers_Settings__c.getInstance();  
-                
+                VolunteersSettings = Volunteers_Settings__c.getInstance();
+
                 if (VolunteersSettings.Id == null) {
-                    VolunteersSettings = Volunteers_Settings__c.getOrgDefaults();                   
+                    VolunteersSettings = Volunteers_Settings__c.getOrgDefaults();
                 }
-                
+
                 if (VolunteersSettings.Id == null) {
                     VolunteersSettings.Setupownerid = UserInfo.getOrganizationId();
 
@@ -181,10 +181,10 @@ global with sharing class VOL_SharedCode {
             }
             return VolunteersSettings;
         }
-        
+
         set;
     }
-    
+
     // helper to get the AccoutId of the Bucket Account specified in Custom Settings.
     global static ID SettingsBucketAccountId {
         get {
@@ -193,10 +193,10 @@ global with sharing class VOL_SharedCode {
                     Account[] acc = [select Id from Account where name = :VolunteersSettings.Signup_Bucket_Account_On_Create__c limit 1];
                     if (acc.size() > 0) SettingsBucketAccountId = acc[0].Id;
                 }
-            } 
+            }
             return SettingsBucketAccountId;
         }
-        
+
         set;
     }
 
@@ -205,7 +205,7 @@ global with sharing class VOL_SharedCode {
         //clear out whatever settings exist
         delete [select id from Volunteers_Settings__c];
         SettingsBucketAccountId = null;
-        
+
         //create our own based on what's passed in from the test
         VolunteersSettings = new Volunteers_Settings__c (
             Signup_Matches_Existing_Contacts__c = mySettings.Signup_Matches_Existing_Contacts__c,
@@ -219,8 +219,8 @@ global with sharing class VOL_SharedCode {
             Personal_Site_Report_Hours_Filtered__c = mySettings.Personal_Site_Report_Hours_Filtered__c
             );
 
-        insert VolunteersSettings;                      
-        return VolunteersSettings;       
+        insert VolunteersSettings;
+        return VolunteersSettings;
     }
 
     // global helper to get the Volunteers Campaign recordtype.
@@ -230,7 +230,7 @@ global with sharing class VOL_SharedCode {
             if (recordtypeIdVolunteersCampaign == null) {
                 list<RecordType> listRT = [SELECT Id FROM RecordType WHERE DeveloperName='Volunteers_Campaign'];
                 if (listRT.size() == 0) {
-                    throw (new MyException('The Volunteers Campaign Record Type is missing and must be restored.'));                    
+                    throw (new MyException('The Volunteers Campaign Record Type is missing and must be restored.'));
                 }
                 recordtypeIdVolunteersCampaign = listRT[0].Id;
             }
@@ -238,36 +238,36 @@ global with sharing class VOL_SharedCode {
         }
         set;
     }
-    
+
     // shared routine to get all Fields names from the specified Field Set on Contact
     // also explicitly adds additional Contact fields that we will always use in our Sites pages.
     global static list<string> listStrFieldsFromContactFieldSet(Schema.FieldSet fs) {
         set<string> setStrFields = new set<string>();
         for (Schema.FieldSetMember f : fs.getFields()) {
             setStrFields.add(f.getFieldPath().toLowerCase());
-        }  
+        }
         // also add the fields we explicitly refer to in CreateOrUpdateContactFS()
         // we use a set (with lowercase) to avoid creating duplicates.
         setStrFields.add('firstname');
         setStrFields.add('lastname');
         setStrFields.add('email');
         //setStrFields.add(VOL_SharedCode.StrTokenNSPrefix('volunteer_status__c').tolowerCase());
-        //setStrFields.add(VOL_SharedCode.StrTokenNSPrefix('volunteer_notes__c').toLowerCase());        
+        //setStrFields.add(VOL_SharedCode.StrTokenNSPrefix('volunteer_notes__c').toLowerCase());
         list<string> listStrFields = new list<string>();
         listStrFields.addAll(setStrFields);
         return listStrFields;
     }
-    
-    // shared routine to get all Fields names form the specified Field Set 
+
+    // shared routine to get all Fields names form the specified Field Set
     global static list<string> listStrFieldsFromFieldSet(Schema.FieldSet fs) {
         list<string> listStrFields = new list<string>();
         for (Schema.FieldSetMember f : fs.getFields()) {
             listStrFields.add(f.getFieldPath());
-        }  
+        }
         return listStrFields;
     }
 
-    // global code to create a new lead or contact for web volunteer signup.  
+    // global code to create a new lead or contact for web volunteer signup.
     // this code is used by both the VolunteersSignup page, and the VolunteersJobListing page.
     // it uses the custom setting for the bucket account, but takes parameters for
     // matching existing contacts, and create contacts vs. leads.  this is because the two pages have different use cases.
@@ -276,11 +276,11 @@ global with sharing class VOL_SharedCode {
     global static ID CreateContactOrLead(Contact contact, boolean fMatchExistingContacts, boolean fCreateContacts) {
         // update the date before we start
         contact.Volunteer_Last_Web_Signup_Date__c = system.today();
-        
+
         // let's see if we can find any matching Contacts.
         list<Contact> listCon = [select Id, Lastname, Firstname, Email, Phone, HomePhone,
-                Volunteer_Availability__c, Volunteer_Notes__c, Volunteer_Last_Web_Signup_Date__c, 
-                Volunteer_Status__c, Volunteer_Skills__c, Volunteer_Organization__c from Contact 
+                Volunteer_Availability__c, Volunteer_Notes__c, Volunteer_Last_Web_Signup_Date__c,
+                Volunteer_Status__c, Volunteer_Skills__c, Volunteer_Organization__c from Contact
                 where Lastname=:contact.Lastname and Firstname=:contact.Firstname and Email=:contact.Email];
 
         Set<String> setFlds = new Set<String>{'Lastname', 'Firstname', 'Email', 'Phone', 'HomePhone',
@@ -292,19 +292,19 @@ global with sharing class VOL_SharedCode {
             UTIL_Describe.StrTokenNSPrefix('Volunteer_Organization__c')};
 
         // if we can match existing contacts, and we found a match, update them.
-        if (fMatchExistingContacts && listCon.size() > 0) {                   
+        if (fMatchExistingContacts && listCon.size() > 0) {
             for (Contact con : listCon) {
                 con.Volunteer_Last_Web_Signup_Date__c = contact.Volunteer_Last_Web_Signup_Date__c;
                 con.Volunteer_Availability__c = contact.Volunteer_Availability__c;
                 string strNotes = con.Volunteer_Notes__c;
-                if (strNotes != '') strNotes += '  '; 
+                if (strNotes != '') strNotes += '  ';
                 if (contact.Volunteer_Notes__c != null) {
                     con.Volunteer_Notes__c = strNotes + '[' + string.valueof(System.today()) + ']: ' + contact.Volunteer_Notes__c;
-                }                   
+                }
                 con.Volunteer_Skills__c = contact.Volunteer_Skills__c;
                 if (con.Volunteer_Status__c == null) con.Volunteer_Status__c = 'New Sign Up';
                 if (contact.Phone != null) con.Phone = contact.Phone;
-                if (contact.HomePhone != null) con.HomePhone = contact.HomePhone; 
+                if (contact.HomePhone != null) con.HomePhone = contact.HomePhone;
                 // NOTE: if we find existing contact(s), we don't worry about doing anything with Company.
                 // but we can at least put it in the new Volunteer_Organization__c field.
                 if (contact.Department != null) con.Volunteer_Organization__c = contact.Department;
@@ -315,21 +315,21 @@ global with sharing class VOL_SharedCode {
         } else if (fCreateContacts) {  // No Match found, create a Contact
             contact.LeadSource = 'Web Volunteer Signup';
             contact.Volunteer_Status__c = 'New Sign Up';
-            
+
             Account accToUse = null;
-            
+
             // see if we can find their company (which we assume the form used Department to record.)
             if (contact.Department != null) {
                 list<Account> listAccount = [select Id, Name from Account where Name = :contact.Department limit 1];
                 if (listAccount.size() > 0) accToUse = listAccount.get(0);
                 contact.Volunteer_Organization__c = contact.Department;
             }
-            
+
             // if company found, use it
             if (accToUse != null) {
                 contact.AccountId = accToUse.Id;
             } else { // otherwise use the bucket account (which may be null and imply the 1:1 model in NPSP)
-                contact.AccountId = VOL_SharedCode.SettingsBucketAccountId;                             
+                contact.AccountId = VOL_SharedCode.SettingsBucketAccountId;
             }
             UTIL_Describe.checkCreateAccess('Contact', setFlds);
             Database.insert(contact, dmlDuplicateOptions);
@@ -355,9 +355,9 @@ global with sharing class VOL_SharedCode {
                     UTIL_Describe.StrTokenNSPrefix('Volunteer_Status__c')});
             Database.insert(lead, dmlDuplicateOptions);
             return lead.Id;
-        }       
-    }   
-    
+        }
+    }
+
     // global code to verify the passed in ContactId is valid, as well as the email
     // exists on the Contact record.
     global static boolean isValidContactIdAndEmail(ID contactId, string strEmail) {
@@ -374,21 +374,21 @@ global with sharing class VOL_SharedCode {
                     strSoql += ' or ' + str + ' = :strEmail ';
                 }
             }
-            // handle NPSP email fields 
+            // handle NPSP email fields
             if (IsNPSPInstalled) {
                 strSoql += ' or npe01__AlternateEmail__c = :strEmail ';
                 strSoql += ' or npe01__HomeEmail__c = :strEmail ';
                 strSoql += ' or npe01__WorkEmail__c = :strEmail ';
             }
             strSoql += ') ';
-        }        
-        list<Contact> listCon = Database.Query(strSoql); 
+        }
+        list<Contact> listCon = Database.Query(strSoql);
         return listCon.size() > 0;
     }
-    
+
     // global code to lookup an existing contact
     // listStrFields are optional fields to include in the soql call
-    global static list<Contact> LookupContact(Contact contact, list<string> listStrFields) {    
+    global static list<Contact> LookupContact(Contact contact, list<string> listStrFields) {
         // let's see if we can find any matching Contacts.
         // we need to use dynamic soql, since we allow the user to modify the FieldSet of fields to edit.
         string strSoql = 'select ';
@@ -400,20 +400,21 @@ global with sharing class VOL_SharedCode {
                 strSoql += strComma + strF;
                 strComma = ', ';
             }
-        }        
+        }
         strSoql += ' from Contact ';
         string strAnd = ' where ';
-        
+
         // make sure their settings haven't been completely cleared
         if (VolunteersSettings.Contact_Matching_Rule__c == null || VolunteersSettings.Contact_Matching_Rule__c == '') {
             VolunteersSettings.Contact_Matching_Rule__c = 'Firstname;Lastname;Email';
         }
-        
-        if (isLastnameInContactMatchRules) {
+
+        final String rule = VolunteersSettings.Contact_Matching_Rule__c;
+        if (rule.containsIgnoreCase(String.valueOf(Contact.LastName))) {
             strSoql += strAnd + ' (Lastname=\'' + StrEscape(contact.Lastname) + '\') ';
             strAnd = ' and ';
         }
-        if (isFirstnameInContactMatchRules) {
+        if (rule.containsIgnoreCase(String.valueOf(Contact.FirstName))) {
             strSoql += strAnd + ' (Firstname=\'' + StrEscape(contact.Firstname) + '\'';
             strAnd = ' and ';
 
@@ -427,7 +428,7 @@ global with sharing class VOL_SharedCode {
             }
             strSoql += ') ';
         }
-        if (isEmailInContactMatchRules) {
+        if (rule.containsIgnoreCase(String.valueOf(Contact.Email))) {
             strSoql += strAnd + ' (Email=\'' + contact.Email + '\'';
             strAnd = ' and ';
             // any additional email fields to check
@@ -438,28 +439,28 @@ global with sharing class VOL_SharedCode {
                     strSoql += ' or ' + str + '=\'' + contact.Email + '\'';
                 }
             }
-            // handle NPSP email fields 
+            // handle NPSP email fields
             if (IsNPSPInstalled) {
                 strSoql += ' or npe01__AlternateEmail__c=\'' + contact.Email + '\'';
                 strSoql += ' or npe01__HomeEmail__c=\'' + contact.Email + '\'';
                 strSoql += ' or npe01__WorkEmail__c=\'' + contact.Email + '\'';
             }
             strSoql += ') ';
-        }        
-        strSoql += ' limit 999 ';      
-        list<Contact> listCon = Database.Query(strSoql); 
+        }
+        strSoql += ' limit 999 ';
+        list<Contact> listCon = Database.Query(strSoql);
         return listCon;
     }
 
-    // global code to create a new contact, or update an existing contact, for web volunteer signup.  
+    // global code to create a new contact, or update an existing contact, for web volunteer signup.
     // this code is used by both the VolunteersSignupFS page, and the VolunteersJobListingFS page.
     // if creating a new Contact, it uses the custom setting for the bucket account, but takes parameters for
     // the account name to try to lookup and match.
     // It also takes the list of fields on the contact object to copy over.
     global static ID CreateOrUpdateContactFS(string contactIdExisting, Contact contact, string strAccountName, list<string> listStrFields) {
-        return CreateOrUpdateContactFS(contactIdExisting, contact, strAccountName, listStrFields, true); 
+        return CreateOrUpdateContactFS(contactIdExisting, contact, strAccountName, listStrFields, true);
     }
-    
+
     global static ID CreateOrUpdateContactFS(string contactIdExisting, Contact contact, string strAccountName, list<string> listStrFields, boolean setLastWebSignup) {
         // listStrFields is the specific list of fields on the form's fieldset, which we should assume we want to save.
         // we also need to special case several fields we will potentially set, but we also need to know,
@@ -469,10 +470,10 @@ global with sharing class VOL_SharedCode {
         // store all fields in lower case
         for (string strField : listStrFields)
             setStrFields.add(strField.toLowerCase());
-            
+
         boolean isStatusInFS = !setStrFields.add(VOL_SharedCode.StrTokenNSPrefix('volunteer_status__c').tolowerCase());
-        boolean isNotesInFS = !setStrFields.add(VOL_SharedCode.StrTokenNSPrefix('volunteer_notes__c').toLowerCase());    
-        
+        boolean isNotesInFS = !setStrFields.add(VOL_SharedCode.StrTokenNSPrefix('volunteer_notes__c').toLowerCase());
+
         // create a new list with all the fields
         list<string> listStrFieldsAll = new list<string>(setStrFields);
 
@@ -481,39 +482,39 @@ global with sharing class VOL_SharedCode {
 
         list<Contact> listCon = LookupContact(contact, listStrFieldsAll);
 
-        // if we found a match                      
+        // if we found a match
         if (listCon.size() > 0) {
             Contact conExisting = null;
-            
+
             // match the one that has the same Id
             if (contactIdExisting != null && contactIdExisting != '') {
-                for (integer i = 0; i < listCon.size(); i++) { 
-                    if (listCon[i].Id == contactIdExisting) 
+                for (integer i = 0; i < listCon.size(); i++) {
+                    if (listCon[i].Id == contactIdExisting)
                         conExisting = listCon[i];
                 }
             }
             // use first one if no match found.
             if (conExisting == null) {
                 conExisting = listCon[0];
-            }                  
-            
+            }
+
             // special case appending Volunteer Notes, rather than overwriting.
             if (isNotesInFS) {
                 if (contact.Volunteer_Notes__c != null && contact.Volunteer_Notes__c != conExisting.Volunteer_Notes__c) {
-                    contact.Volunteer_Notes__c = (conExisting.Volunteer_Notes__c != null ? (conExisting.Volunteer_Notes__c + '  ') : '') + 
+                    contact.Volunteer_Notes__c = (conExisting.Volunteer_Notes__c != null ? (conExisting.Volunteer_Notes__c + '  ') : '') +
                         '[' + string.valueof(System.today()) + ']: ' + contact.Volunteer_Notes__c;
                 } else {
                     contact.Volunteer_Notes__c = conExisting.Volunteer_Notes__c;
                 }
             }
-                        
+
             // special case setting Volunteer Status, only if not currently set.
             if (conExisting.Volunteer_Status__c != null) {
                 contact.Volunteer_Status__c = null;
             } else {
                 conExisting.Volunteer_Status__c = 'New Sign Up';
             }
-            
+
             // now copy over all the non-null fields from the form's contact to the existing contact.
             // avoid overwriting existing first name or existing email, since we might match it from in a different field.
             // special case address fields
@@ -537,12 +538,12 @@ global with sharing class VOL_SharedCode {
                     }
                     conExisting.put(strF, contact.get(strF));
                 }
-            }            
+            }
             if (hasMailingAddress)
                 VOL_StateCountryPicklists.copyAddressStdSObj(contact, 'Mailing', conExisting, 'Mailing');
             if (hasOtherAddress)
                 VOL_StateCountryPicklists.copyAddressStdSObj(contact, 'Other', conExisting, 'Other');
-                
+
             if (setLastWebSignup)
                 conExisting.Volunteer_Last_Web_Signup_Date__c = system.today();
 
@@ -580,20 +581,20 @@ global with sharing class VOL_SharedCode {
             if (hasOtherAddress)
                 VOL_StateCountryPicklists.copyAddressStdSObj(contact, 'Other', conNew, 'Other');
 
-            // see if we can find their company 
-            Account accToUse = null;            
+            // see if we can find their company
+            Account accToUse = null;
             if (strAccountName != null) {
                 list<Account> listAccount = [select Id, Name from Account where Name = :strAccountName limit 1];
                 if (listAccount.size() > 0) accToUse = listAccount.get(0);
             }
-            
+
             // if company found, use it
             if (accToUse != null) {
                 conNew.AccountId = accToUse.Id;
             } else { // otherwise use the bucket account (which may be null and imply the 1:1 model in NPSP)
-                conNew.AccountId = VOL_SharedCode.SettingsBucketAccountId;                             
+                conNew.AccountId = VOL_SharedCode.SettingsBucketAccountId;
             }
-            
+
             if (setLastWebSignup)
                 conNew.Volunteer_Last_Web_Signup_Date__c = system.today();
             conNew.LeadSource = 'Web Volunteer Signup';
@@ -604,7 +605,7 @@ global with sharing class VOL_SharedCode {
             // null out notes, so another update won't append them again!
             contact.Volunteer_Notes__c = null;
             return conNew.Id;
-        }       
+        }
     }
 
     /*******************************************************************************************************
@@ -630,33 +631,33 @@ global with sharing class VOL_SharedCode {
         if (str == null) return null;
         return string.escapeSingleQuotes(str);
     }
-    
+
     // global utility to load up an existing object and copy it to the provided object
     global static void LoadAndCopyObject(ID id, SObject sobj) {
-        
+
         // this code moved to VOL_SharedCodeAPI25 to keep it running with api 25
         // behavior, which is that the Sites Guest User Profile can still edit
         // this new contact object we created.  Under api 31, the contact object is readonly.
         // we needed to update the rest of this class to api 31 to handle state & country picklists.
         VOL_SharedCodeAPI25.LoadAndCopyObject(id, sobj, null);
     }
-    
+
     public static void VolunteerHoursTrigger(list<Volunteer_Hours__c> listHoursOld, list<Volunteer_Hours__c> listHoursNew, boolean resetTotals) {
-        
+
         // consider both newMap and oldMap.
         // for each hours object, there are two potential shifts it interacts with.
         // within a batch of hours changes (import scenario), multiple hours can affect the same shift.
         // thus need to keep track of the shifts to update, their original value, and the sum of their changed values.
-        
+
         // Insert scenario: status=Confirmed or Completed. Shift <> null. Number of Volunteers <> null.
         // Delete scenario: status=Confirmed or Completed.  Shift <> null. Number of Volunteers <> null.
         // Update scenario: just treat as a delete and an insert, since we already have to handle multiple changes to same job!
-        
-    
+
+
         // WARNING: deleting, undeleting, or merging a Contact, does NOT call any trigger on the Hours!
         // thus I've manually called this from the before delete & after undelete trigger on Contacts (VOL_Contact_MaintainHours).
         map<Id, Double> mpShiftIdDelta = new map<Id, Double>();
-        
+
         // first we go through the new hours, and add up the number of volunteers per shift
         if (listHoursNew != null) {
             for (Volunteer_Hours__c hr : listHoursNew) {
@@ -667,10 +668,10 @@ global with sharing class VOL_SharedCode {
                         numVols += hr.Number_of_Volunteers__c;
                         mpShiftIdDelta.put(hr.Volunteer_Shift__c, numVols);
                     }
-            } 
+            }
         }
-        
-        // second we go through the old hours, and subtract the number of volunteers per shift      
+
+        // second we go through the old hours, and subtract the number of volunteers per shift
         if (listHoursOld != null) {
             for (Volunteer_Hours__c hr : listHoursOld) {
                 if ((hr.Status__c == 'Confirmed' || hr.Status__c == 'Completed') &&
@@ -680,17 +681,17 @@ global with sharing class VOL_SharedCode {
                         numVols -= hr.Number_of_Volunteers__c;
                         mpShiftIdDelta.put(hr.Volunteer_Shift__c, numVols);
                     }
-            } 
+            }
         }
-        
+
         // bail out if nothing found (to avoid runtime error!)
         if (mpShiftIdDelta.size() == 0)
             return;
-            
+
         // now that we have the Id's of the shifts, let's get them from the database, update them by the number of volunteers, and then commit.
         //list<Volunteer_Shift__c> listShifts = new list<Volunteer_Shift__c>();
         for (list<Volunteer_Shift__c> listShifts : [select Id, Total_Volunteers__c from Volunteer_Shift__c where Id in :mpShiftIdDelta.keySet()]) {
-            
+
             // loop through and update them
             for (Volunteer_Shift__c shift : listShifts) {
                 Double numVols = shift.Total_Volunteers__c;
@@ -698,10 +699,10 @@ global with sharing class VOL_SharedCode {
                 shift.Total_Volunteers__c = numVols + mpShiftIdDelta.get(shift.Id);
             }
             update listShifts;
-        }       
+        }
     }
-    
-    
+
+
     // global utility used to detect whether the Non Profit Starter Pack is installed in this instance.
     private static boolean fCheckedForNPSP = false;
     global static boolean IsNPSPInstalled {
@@ -714,8 +715,8 @@ global with sharing class VOL_SharedCode {
             return IsNPSPInstalled;
         }
         set;
-    }   
-    
+    }
+
     // global utility used to detect whether the Volunteers is running in a managed instance or unmanaged instance
     private static boolean fCheckedForVolunteersNamespace = false;
     global static boolean IsManagedCode {
@@ -727,13 +728,13 @@ global with sharing class VOL_SharedCode {
                 //IsManagedCode = (token != null);
 
                 IsManagedCode = (getNamespace() != '');
-                
+
                 fCheckedForVolunteersNamespace = true;
             }
             return IsManagedCode;
         }
         set;
-    }   
+    }
 
     /******************************************************************************************************
     * @description String helper property for getNamespace() method.
@@ -761,7 +762,7 @@ global with sharing class VOL_SharedCode {
     * @description Static method that takes a string
     * If we are in a managed package, tokens in dynamic SOQL must include the package namespace prefix.
     * If you ever deploy this package as unmanaged, this routine will do nothing!
-    * @param str token name 
+    * @param str token name
     * @return token name, with namespace prefix, if required.
     ********************************************************************************************************/
     global static string StrTokenNSPrefix(string str) {
@@ -769,43 +770,16 @@ global with sharing class VOL_SharedCode {
         str = getNamespace() + '__' + str;
         return str;
     }
-  
-    private static boolean isFirstnameInContactMatchRules {
-        get {
-            string str = VolunteersSettings.Contact_Matching_Rule__c;
-            if (str == null || str == '')
-                return false;
-            return str.contains('Firstname');
-        }
-    }
-
-    private static boolean isLastnameInContactMatchRules {
-        get {
-            string str = VolunteersSettings.Contact_Matching_Rule__c;
-            if (str == null || str == '')
-                return false;
-            return str.contains('Lastname');
-        }
-    }
-
-    private static boolean isEmailInContactMatchRules {
-        get {
-            string str = VolunteersSettings.Contact_Matching_Rule__c;
-            if (str == null || str == '')
-                return false;
-            return str.contains('Email');
-        }
-    } 
 
     // utility to verify all the specified fields are accessible to the current user.
     // fields that are not accessible will have a pageMessage added to the current page
     // so the warning is displayed to the user.
     global static void testObjectFieldVisibility(string strObj, list<string>listStrField) {
-        
+
         Map<String, Schema.SObjectType> gd;
         Schema.DescribeSObjectResult sobjDescr;
         Map<String, Schema.SObjectField> mapFieldDesc;
-        
+
         // Obtaining the field name/token map for the object
         gd = Schema.getGlobalDescribe();
         if (gd != null)
@@ -815,12 +789,12 @@ global with sharing class VOL_SharedCode {
         if (mapFieldDesc !=  null)
             for (String strField : listStrField) {
                 // Check if the user has access on the each field
-                // note that fields in our own package must not have their prefix for the Describe Field Map  
-                Schema.SObjectField fld = mapFieldDesc.get(strField.replace(StrTokenNSPrefix(''), ''));     
+                // note that fields in our own package must not have their prefix for the Describe Field Map
+                Schema.SObjectField fld = mapFieldDesc.get(strField.replace(StrTokenNSPrefix(''), ''));
                 if (fld != null && !fld.getDescribe().isAccessible()) {
                     ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.FATAL, 'Field ' + strObj + '.' + strField +
                         ' You need to enable field level security for this field on the Site\'s Guest User profile.'));
-                } 
+                }
             }
     }
 
@@ -855,18 +829,18 @@ global with sharing class VOL_SharedCode {
     }
 
     // This massively nested SOQL where statement looks hard coded and dumb, but as it turns out
-    // there's a limit on number of campaign hierarchy levels anyway, so this isn't as dumb as it 
+    // there's a limit on number of campaign hierarchy levels anyway, so this isn't as dumb as it
     // seems. This method will get all campaigns in hierarchy, and keeps the logic in a single query
 
     /*******************************************************************************************************
     * @description Static method that takes an Id
     * Return a list of Campaign Ids that are children/grand-children &c of the given Campaign.
-    * @param Id for any campaign 
+    * @param Id for any campaign
     * @return List<Id> of child campaigns
     ********************************************************************************************************/
     global static List<Id> listIdsCampaignsInHierarchy(Id campaignId) {
         Map<Id,Campaign> campaignsInHierarchy = new Map<Id,Campaign>(
-            [SELECT Id,Name FROM Campaign WHERE IsActive =:true  
+            [SELECT Id,Name FROM Campaign WHERE IsActive =:true
              AND RecordTypeId =: recordtypeIdVolunteersCampaign AND
             (Id =: campaignId
              OR ParentId =: campaignId
@@ -877,7 +851,7 @@ global with sharing class VOL_SharedCode {
         );
         return new List<Id>(campaignsInHierarchy.keySet());
     }
-    
+
     /*******************************************************************************************************
     * @description keeps references to old labels that have been packaged, that we no longer use.
     * @return void
@@ -899,5 +873,5 @@ global with sharing class VOL_SharedCode {
         str = Label.labelFindVolunteersHelpAssign;
         str = Label.labelVolunteersWizardNewCampaignTitle;
     }
-     
+
 }

--- a/src/classes/VOL_SharedCode_TEST.cls
+++ b/src/classes/VOL_SharedCode_TEST.cls
@@ -1,10 +1,10 @@
 /*
     Copyright (c) 2016, Salesforce.org
     All rights reserved.
-    
+
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
-    
+
     * Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above copyright
@@ -13,18 +13,18 @@
     * Neither the name of Salesforce.org nor the names of
       its contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
- 
+
     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
     POSSIBILITY OF SUCH DAMAGE.
 */
 
@@ -34,52 +34,52 @@ public with sharing class VOL_SharedCode_TEST {
 
     //==================== TEST METHOD(s) ======================================
     static testmethod void CodeCoverageTests() {
-        // since this class is all shared code, it gets heavily exercised by all other test code.       
+        // since this class is all shared code, it gets heavily exercised by all other test code.
         // we just need to add a test for hitting the scenario where there aren't any settings specified in the instance.
-        
+
         //clear out whatever settings exist
         delete [select id from Volunteers_Settings__c];
         System.Assert(VOL_SharedCode.VolunteersSettings != null);
         System.Assert(VOL_SharedCode.VolunteersSettings.Signup_Bucket_Account_On_Create__c == null);
-        
+
         Contact c = new Contact(lastname='foo');
         insert c;
         Contact c2 = new Contact();
         VOL_SharedCode.LoadAndCopyObject(c.Id, c2);
         System.assertEquals('foo', c2.LastName);
-            
+
         Contact c3 = new Contact();
         VOL_SharedCodeAPI25.LoadAndCopyObject(c.Id, c3, null);
         System.assertEquals('foo', c3.LastName);
     }
-    
+
     /*******************************************************************************************************
     * @description test methods to test all permutations of the Contact Matching Rule.
     * @return void
-    */ 
+    */
     static testmethod void testContactMatchRule1() {
-    	testContactMatchRule('Firstname;Lastname;Email');
+        testContactMatchRule('Firstname;Lastname;Email');
     }
     static testmethod void testContactMatchRule2() {
-    	testContactMatchRule('Firstname;Lastname');
+        testContactMatchRule('Firstname;Lastname');
     }
     static testmethod void testContactMatchRule3() {
-    	testContactMatchRule('Firstname;Email');
+        testContactMatchRule('Firstname;Email');
     }
     static testmethod void testContactMatchRule4() {
-    	testContactMatchRule('Lastname;Email');
+        testContactMatchRule('Lastname;Email');
     }
     static testmethod void testContactMatchRule5() {
-    	testContactMatchRule('');
+        testContactMatchRule('');
     }
     static testmethod void testContactMatchRule6() {
-    	testContactMatchRule('Firstname;');
+        testContactMatchRule('Firstname;');
     }
     static testmethod void testContactMatchRule7() {
-    	testContactMatchRule('Lastname');
+        testContactMatchRule('Lastname');
     }
     static testmethod void testContactMatchRule8() {
-    	testContactMatchRule('Email');
+        testContactMatchRule('Email');
     }
     static void testContactMatchRule(string strRule) {
 
@@ -89,49 +89,49 @@ public with sharing class VOL_SharedCode_TEST {
         settings.Contact_Matching_Rule__c = strRule;
         VOL_SharedCode.getVolunteersSettingsForTests(settings);
 
-		// test data
-		list<Contact> listCon = new list<Contact>();
-		listCon.add(new Contact(Firstname='Fred', Lastname='Smith', Email='fred@smith.com'));
-		listCon.add(new Contact(Firstname='Fred', Lastname='Smith', Email=null));
-		listCon.add(new Contact(Firstname='Fred', Lastname='Smith', Email='NOTfred@smith.com'));
-		listCon.add(new Contact(Firstname='NOTFred', Lastname='Smith', Email='fred@smith.com'));
-		listCon.add(new Contact(Firstname='Fred', Lastname='NOTSmith', Email='fred@smith.com'));
-		insert listCon;
-		
-        list<string> listStrFields = new list<string>{'Id', 'Firstname', 'Lastname', 'Email'};        
-		list<Contact> listCon2 = VOL_SharedCode.LookupContact(listCon[0], listStrFields);
-		
-		if (strRule == 'Firstname;Lastname;Email') {
-			system.assertEquals(1, listCon2.size());
-		}
-		if (strRule == 'Firstname;Email') {
-			system.assertEquals(2, listCon2.size());
-		}
-		if (strRule == 'Lastname;Email') {
-			system.assertEquals(2, listCon2.size());
-		}
-		if (strRule == 'Firstname;Lastname') {
-			system.assertEquals(3, listCon2.size());
-		}
-		if (strRule == 'Email') {
-			system.assertEquals(3, listCon2.size());
-		}
-		if (strRule == 'Firstname') {
-			system.assertEquals(4, listCon2.size());
-		}
-		if (strRule == 'Lastname') {
-			system.assertEquals(4, listCon2.size());
-		}
-		if (strRule == '') {  // we treat blank as 'Firstname;Lastname;Email'
-			system.assertEquals(1, listCon2.size());
-		}
+        // test data
+        list<Contact> listCon = new list<Contact>();
+        listCon.add(new Contact(Firstname='Fred', Lastname='Smith', Email='fred@smith.com'));
+        listCon.add(new Contact(Firstname='Fred', Lastname='Smith', Email=null));
+        listCon.add(new Contact(Firstname='Fred', Lastname='Smith', Email='NOTfred@smith.com'));
+        listCon.add(new Contact(Firstname='NOTFred', Lastname='Smith', Email='fred@smith.com'));
+        listCon.add(new Contact(Firstname='Fred', Lastname='NOTSmith', Email='fred@smith.com'));
+        insert listCon;
+
+        list<string> listStrFields = new list<string>{'Id', 'Firstname', 'Lastname', 'Email'};
+        list<Contact> listCon2 = VOL_SharedCode.LookupContact(listCon[0], listStrFields);
+
+        if (strRule == 'Firstname;Lastname;Email') {
+            system.assertEquals(1, listCon2.size());
+        }
+        if (strRule == 'FIRSTNAME;Email') {
+            system.assertEquals(2, listCon2.size());
+        }
+        if (strRule == 'lastName;email') {
+            system.assertEquals(2, listCon2.size());
+        }
+        if (strRule == 'Firstname;Lastname') {
+            system.assertEquals(3, listCon2.size());
+        }
+        if (strRule == 'Email') {
+            system.assertEquals(3, listCon2.size());
+        }
+        if (strRule == 'Firstname') {
+            system.assertEquals(4, listCon2.size());
+        }
+        if (strRule == 'Lastname') {
+            system.assertEquals(4, listCon2.size());
+        }
+        if (strRule == '') {  // we treat blank as 'Firstname;Lastname;Email'
+            system.assertEquals(1, listCon2.size());
+        }
     }
-    
-    
-	/*******************************************************************************************************
-	* @description creates a hierarchy of volunteer campaigns, each with a job and a shift.
-	* @return a map of campaigns created, with name as their key.
-	*
+
+
+    /*******************************************************************************************************
+    * @description creates a hierarchy of volunteer campaigns, each with a job and a shift.
+    * @return a map of campaigns created, with name as their key.
+    *
     * └── grandparent
     *     ├── parent1
     *     │   ├── child1
@@ -143,7 +143,7 @@ public with sharing class VOL_SharedCode_TEST {
     *             ├── grandchild1
     *             ├── grandchild2
     *             └── grandchild3
-	* 
+    *
     */
     public static map<string, Campaign> mapCampaignTestHierarchy() {
         // build campaign hierarchy as shown above
@@ -162,30 +162,30 @@ public with sharing class VOL_SharedCode_TEST {
         Campaign grandchild2 =  new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, ParentId = child5.Id, name='Grandchild 2 of 3', IsActive=true);
         Campaign grandchild3 =  new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, ParentId = child5.Id, name='Grandchild 3 of 3', IsActive=true);
         insert new List<Campaign> {grandchild1,grandchild2,grandchild3};
-    
-    	list<Campaign> listCampaign = new list<Campaign> {grandParent, parent1, parent2, child1, child2, child3, child4, child5, grandchild1, grandchild2, grandchild3};
-    	list<Volunteer_Job__c> listJob = new list<Volunteer_Job__c>();
-    	map<string, Campaign> mapCampaign = new map<string, Campaign>();
-    	for (Campaign cmp : listCampaign) {
-    		listJob.add(new Volunteer_Job__c(name=cmp.Name, Campaign__c=cmp.Id, Display_on_Website__c=true));
-    		mapCampaign.put(cmp.Name, cmp);
-    	}
-    	insert listJob;
-    	
-    	
-    	list<Volunteer_Shift__c> listShift = new list<Volunteer_Shift__c>();
-    	for (Volunteer_Job__c job : listJob) {
-    		listShift.add(new Volunteer_Shift__c(Volunteer_Job__c=job.Id, Duration__c=1, Start_Date_Time__c=System.Now().addDays(1)));
-    	}
-    	insert listShift;
-    	
-    	return mapCampaign;
+
+        list<Campaign> listCampaign = new list<Campaign> {grandParent, parent1, parent2, child1, child2, child3, child4, child5, grandchild1, grandchild2, grandchild3};
+        list<Volunteer_Job__c> listJob = new list<Volunteer_Job__c>();
+        map<string, Campaign> mapCampaign = new map<string, Campaign>();
+        for (Campaign cmp : listCampaign) {
+            listJob.add(new Volunteer_Job__c(name=cmp.Name, Campaign__c=cmp.Id, Display_on_Website__c=true));
+            mapCampaign.put(cmp.Name, cmp);
+        }
+        insert listJob;
+
+
+        list<Volunteer_Shift__c> listShift = new list<Volunteer_Shift__c>();
+        for (Volunteer_Job__c job : listJob) {
+            listShift.add(new Volunteer_Shift__c(Volunteer_Job__c=job.Id, Duration__c=1, Start_Date_Time__c=System.Now().addDays(1)));
+        }
+        insert listShift;
+
+        return mapCampaign;
     }
 
 
     static testmethod void testCampaignHierarchy() {
         // build campaign hierarchy as shown above
-		map<string, Campaign> mapCmp = mapCampaignTestHierarchy();
+        map<string, Campaign> mapCmp = mapCampaignTestHierarchy();
 
         // get a few trees
         List<Id> parent2Tree = VOL_SharedCode.listIdsCampaignsInHierarchy(mapCmp.get('Parent 2 of 2').Id);
@@ -209,30 +209,30 @@ public with sharing class VOL_SharedCode_TEST {
 
     }
 
-	// tests for the isValidContactIdAndEmail(ID contactId, string strEmail) method
-	static testmethod void testIsValidContactIdAndEmail() {
-		// create an account and contact
-		Account acc = new Account(Name='my test account');
-		insert acc;
-		Contact con = new Contact(Lastname='test contact', AccountId=acc.Id, Email='foo@bar.com');
-		insert con;
-		Contact con2 = new Contact(Lastname='another test contact', AccountId=acc.Id, Email='bar@baz.com');
-		insert con2;
-		
-		// tests with email matching not required
-		VOL_SharedCode.VolunteersSettings.Personal_Site_Requires_URL_Email_Match__c = false;
-		system.assertEquals(false, VOL_SharedCode.isValidContactIdAndEmail(null, null));
-		system.assertEquals(true, VOL_SharedCode.isValidContactIdAndEmail(con.Id, null));
-		system.assertEquals(true, VOL_SharedCode.isValidContactIdAndEmail(con.Id, 'bar@baz.com'));
-		system.assertEquals(true, VOL_SharedCode.isValidContactIdAndEmail(con.Id, 'foo@bar.com'));
+    // tests for the isValidContactIdAndEmail(ID contactId, string strEmail) method
+    static testmethod void testIsValidContactIdAndEmail() {
+        // create an account and contact
+        Account acc = new Account(Name='my test account');
+        insert acc;
+        Contact con = new Contact(Lastname='test contact', AccountId=acc.Id, Email='foo@bar.com');
+        insert con;
+        Contact con2 = new Contact(Lastname='another test contact', AccountId=acc.Id, Email='bar@baz.com');
+        insert con2;
 
-		// tests with email matching required
-		VOL_SharedCode.VolunteersSettings.Personal_Site_Requires_URL_Email_Match__c = true;
-		system.assertEquals(false, VOL_SharedCode.isValidContactIdAndEmail(null, null));
-		system.assertEquals(false, VOL_SharedCode.isValidContactIdAndEmail(con.Id, null));
-		system.assertEquals(false, VOL_SharedCode.isValidContactIdAndEmail(con.Id, 'bar@baz.com'));
-		system.assertEquals(true, VOL_SharedCode.isValidContactIdAndEmail(con.Id, 'foo@bar.com'));
-	}
+        // tests with email matching not required
+        VOL_SharedCode.VolunteersSettings.Personal_Site_Requires_URL_Email_Match__c = false;
+        system.assertEquals(false, VOL_SharedCode.isValidContactIdAndEmail(null, null));
+        system.assertEquals(true, VOL_SharedCode.isValidContactIdAndEmail(con.Id, null));
+        system.assertEquals(true, VOL_SharedCode.isValidContactIdAndEmail(con.Id, 'bar@baz.com'));
+        system.assertEquals(true, VOL_SharedCode.isValidContactIdAndEmail(con.Id, 'foo@bar.com'));
+
+        // tests with email matching required
+        VOL_SharedCode.VolunteersSettings.Personal_Site_Requires_URL_Email_Match__c = true;
+        system.assertEquals(false, VOL_SharedCode.isValidContactIdAndEmail(null, null));
+        system.assertEquals(false, VOL_SharedCode.isValidContactIdAndEmail(con.Id, null));
+        system.assertEquals(false, VOL_SharedCode.isValidContactIdAndEmail(con.Id, 'bar@baz.com'));
+        system.assertEquals(true, VOL_SharedCode.isValidContactIdAndEmail(con.Id, 'foo@bar.com'));
+    }
 
     static testmethod void testAddressFieldDetection() {
         system.assertEquals(true, VOL_SharedCode.isMailingAddressField('MailingCity'));


### PR DESCRIPTION
// Applied a quick fix, we will need to refactor this method when we work on the encryption work item. Suggest changing the diff settings to ignore white space, converted tabs to spaces and trimmed trailing whitespace.

# Critical Changes

# Changes

# Issues Closed
Fixes #368 

# New Metadata

# Deleted Metadata
