### PR TITLE
Default to 7 days for dev_namespaced scratch org

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -8,23 +8,6 @@ project:
         prefix_release: rel/
 
 tasks:
-    browsertests_chrome:
-        description: Runs the Ruby/Watir browser tests in the browsertests folder using Chrome
-        class_path: cumulusci.tasks.command.SalesforceBrowserTest
-        options:
-            command: 'cd browser_tests; bundle install --quiet; bundle exec cucumber --format pretty --format junit --out ../junit -c features/ --tags ~@firefox --tags ~@flaky'
-            dir: '.'
-            env:
-                SELENIUM_BROWSER: chrome
-
-    download_browser_tests:
-        description: Downloads the browser tests from the HEDA-Browser-Tests Github repository.
-        class_path: cumulusci.tasks.util.DownloadZip
-        options:
-            url: 'https://github.com/SalesforceFoundation/V4S-Browser-Tests/archive/master.zip'
-            dir: browser_tests
-            subfolder: V4S-Browser-Tests-master
-
     deploy_dev_config:
         description: Deploys the post install configuration for an unmanaged DE org
         class_path: cumulusci.tasks.salesforce.Deploy
@@ -53,32 +36,6 @@ tasks:
                 insert new PermissionSetAssignment(PermissionSetId=psetId, AssigneeId=guestId);
 
 flows:
-    browsertests_chrome:
-        description: Runs the browser tests locally against a managed package in Chrome
-        tasks:
-            1:
-                task: download_browser_tests
-            2:
-                task: browsertests_chrome
-
-    browsertests_chrome:
-        description: Runs the browser tests locally against a managed package in Chrome
-        tasks:
-            1:
-                task: download_browser_tests
-            2:
-                task: browsertests_chrome
-
-    ci_browsertests_chrome:
-        description: Runs the browser tests locally against a managed package in Chrome
-        tasks:
-            1:
-                task: download_browser_tests
-            2:
-                task: browsertests_chrome
-                options:
-                    use_saucelabs: True
-
     ci_feature:
         description: Deploys the unmanaged package metadata and all dependencies to the target org and runs tests
         tasks:
@@ -100,5 +57,4 @@ orgs:
         dev_namespaced:
             config_file: orgs/dev.json
             namespaced: True
-        browsertest_classic:
-            config_file: orgs/browsertest_classic.json
+            days: 7


### PR DESCRIPTION
Also remove old pre-Robot Framework browsertest stuff that we aren't using

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
