### PR TITLE
Updated VRS processing to avoid reparenting hours between different VRSs

### DIFF
--- a/src/classes/VOL_VRS.cls
+++ b/src/classes/VOL_VRS.cls
@@ -47,10 +47,10 @@ public with sharing class VOL_VRS {
         }
 
         // get all hours associated with these VRS's
-        list<Volunteer_Hours__c> listHours =  [select Id, Status__c, Shift_Start_Date_Time__c, 
+        list<Volunteer_Hours__c> listHours =  [SELECT Id, Status__c, Shift_Start_Date_Time__c, 
             Volunteer_Recurrence_Schedule__r.Name, Volunteer_Recurrence_Schedule__c, System_Note__c 
             from Volunteer_Hours__c  
-            where Volunteer_Recurrence_Schedule__c in : setVRSId];
+            WHERE Volunteer_Recurrence_Schedule__c IN : setVRSId];
             
         deleteOrDetachVRSHours(listHours);       
     }
@@ -120,13 +120,13 @@ public with sharing class VOL_VRS {
         // get appropriate shifts of the jobs these vrs's are associated with
         list<Volunteer_Shift__c> listShift = new list<Volunteer_Shift__c>();
         if (fReviewAllShifts) {
-            listShift = [select Id, Duration__c, Start_Date_Time__c, Desired_Number_of_Volunteers__c, 
-                Volunteer_Job__c from Volunteer_Shift__c
-                where Volunteer_Job__c in :setJobId];
+            listShift = [SELECT Id, Duration__c, Start_Date_Time__c, Desired_Number_of_Volunteers__c, 
+                Volunteer_Job__c FROM Volunteer_Shift__c
+                WHERE Volunteer_Job__c IN :setJobId];
         } else {
-            listShift = [select Id, Duration__c, Start_Date_Time__c, Desired_Number_of_Volunteers__c, 
-                Volunteer_Job__c from Volunteer_Shift__c
-                where Volunteer_Job__c in :setJobId and Start_Date_Time__c >= TODAY];
+            listShift = [SELECT Id, Duration__c, Start_Date_Time__c, Desired_Number_of_Volunteers__c, 
+                Volunteer_Job__c FROM Volunteer_Shift__c
+                WHERE Volunteer_Job__c IN :setJobId and Start_Date_Time__c >= TODAY];
         }
         
         // construct a map of Job to its associated list of VRS's
@@ -145,15 +145,20 @@ public with sharing class VOL_VRS {
         // already have an hours record for the given shift and contact.
         list<Volunteer_Hours__c> listHoursExisting = new list<Volunteer_Hours__c>();
         if (fReviewAllShifts) { 
-            listHoursExisting = [select Id, Volunteer_Job__c, Volunteer_Recurrence_Schedule__c,
-                Shift_Start_Date_Time__c, Volunteer_Recurrence_Schedule__r.Name, System_Note__c,
-                Volunteer_Shift__c, Status__c, Contact__c from
-                Volunteer_Hours__c where Volunteer_Job__c in :setJobId and Contact__c in :setContactId];
+            listHoursExisting = [
+                SELECT Id, Volunteer_Job__c, Volunteer_Recurrence_Schedule__c, Shift_Start_Date_Time__c,
+                Volunteer_Recurrence_Schedule__r.Name, System_Note__c, Volunteer_Shift__c, Status__c, Contact__c
+                FROM Volunteer_Hours__c 
+                WHERE Volunteer_Job__c IN :setJobId AND Contact__c IN :setContactId
+                
+            ];
         } else {
-            listHoursExisting = [select Id, Volunteer_Job__c, Volunteer_Recurrence_Schedule__c,
-                Shift_Start_Date_Time__c, Volunteer_Recurrence_Schedule__r.Name, System_Note__c,
-                Volunteer_Shift__c, Status__c, Contact__c from
-                Volunteer_Hours__c where Volunteer_Job__c in :setJobId and Contact__c in :setContactId and Shift_Start_Date_Time__c >= TODAY];
+            listHoursExisting = [
+                SELECT Id, Volunteer_Job__c, Volunteer_Recurrence_Schedule__c, Shift_Start_Date_Time__c, 
+                Volunteer_Recurrence_Schedule__r.Name, System_Note__c, Volunteer_Shift__c, Status__c, Contact__c
+                FROM Volunteer_Hours__c
+                WHERE Volunteer_Job__c IN :setJobId AND Contact__c IN :setContactId AND Shift_Start_Date_Time__c >= TODAY
+            ];
         }
         map<string, Volunteer_Hours__c> mapShiftIdContactIdToHours = new map<string, Volunteer_Hours__c>();
         for (Volunteer_Hours__c hr : listHoursExisting) {
@@ -262,6 +267,11 @@ public with sharing class VOL_VRS {
                 // note that if we match, we remove the key from the map, so we know it was matched.
                 Volunteer_Hours__c hrExisting = mapShiftIdContactIdToHours.get(shift.Id + '|' + vrs.Contact__c);
                 if (hrExisting != null) {
+                    // only operate on hours from the current VRS or not yet belonging to a VRS to avoid reparenting hours from another VRS
+                    if (hrExisting.Volunteer_Recurrence_Schedule__c != null && hrExisting.Volunteer_Recurrence_Schedule__c != vrs.Id) {
+                        continue;
+                    }
+
                     // if shift/hour in the future, we update a subset of fields (Not Status though!)
                     if (dtShift >= System.today()) {
                         hrExisting.Hours_Worked__c = vrs.Duration__c;

--- a/src/classes/VOL_VRS_TEST.cls
+++ b/src/classes/VOL_VRS_TEST.cls
@@ -474,10 +474,10 @@ private with sharing class VOL_VRS_TEST {
         system.assertEquals(4, listHours.size());
         
         listHours = [select Id, Status__c, Planned_Start_Date_Time__c from Volunteer_Hours__c where Volunteer_Recurrence_Schedule__c = :vrs1.Id order by Planned_Start_Date_Time__c];
-        system.assertEquals(0, listHours.size());
+        system.assertEquals(2, listHours.size());
         
         listHours = [select Id, Status__c, Planned_Start_Date_Time__c from Volunteer_Hours__c where Volunteer_Recurrence_Schedule__c = :vrs2.Id order by Planned_Start_Date_Time__c];
-        system.assertEquals(4, listHours.size());
+        system.assertEquals(2, listHours.size());
         
         listHours = [select Id, Status__c from Volunteer_Hours__c where Status__c = 'My Custom Status1' ];
         system.assertEquals(2, listHours.size());
@@ -548,10 +548,10 @@ private with sharing class VOL_VRS_TEST {
         system.assertEquals(4, listHours.size());
         
         listHours = [select Id, Status__c, Planned_Start_Date_Time__c from Volunteer_Hours__c where Volunteer_Recurrence_Schedule__c = :vrs1.Id order by Planned_Start_Date_Time__c];
-        system.assertEquals(0, listHours.size());
+        system.assertEquals(2, listHours.size());
         
         listHours = [select Id, Status__c, Planned_Start_Date_Time__c from Volunteer_Hours__c where Volunteer_Recurrence_Schedule__c = :vrs2.Id order by Planned_Start_Date_Time__c];
-        system.assertEquals(4, listHours.size());
+        system.assertEquals(2, listHours.size());
         
         listHours = [select Id, Status__c from Volunteer_Hours__c where Status__c = 'My Custom Status1' ];
         system.assertEquals(2, listHours.size());
@@ -880,4 +880,92 @@ private with sharing class VOL_VRS_TEST {
         system.assertEquals(1, listHours.size());
     }
 
+
+    //******************************************************************************************************
+    // Test a single Contact with two VRS for two different JRS occuring on the same day.
+    // VRS insert, and then second VRS inserted.  Hours from first VRS should not be reparented to second VRS.
+    private static testmethod void OneContactTwoVRS() {
+
+        // create test data
+        Campaign cmp = new Campaign(recordtypeid=VOL_SharedCode.recordtypeIdVolunteersCampaign, 
+            name='Job Calendar Test Campaign', IsActive=true);
+        insert cmp;
+        Volunteer_Job__c job = new Volunteer_Job__c(name='Job1', campaign__c=cmp.Id);
+        insert job;
+        
+        Contact con = new Contact(firstname='test1', lastname='test1');
+        insert con;
+        
+        DateTime startTime = DateTime.newInstance(System.today().addmonths(-1).toStartOfMonth(), Time.newInstance(10,0,0,0));
+        
+        Job_Recurrence_Schedule__c jrs1 = new Job_Recurrence_Schedule__c(Volunteer_Job__c = job.Id);
+        jrs1.Days_of_Week__c = 'Monday;';
+        jrs1.Duration__c = 1;
+        jrs1.Schedule_Start_Date_Time__c = startTime;
+        jrs1.Weekly_Occurrence__c = '2nd';
+        jrs1.Desired_Number_of_Volunteers__c = 5;
+        insert jrs1;
+
+        List<Volunteer_Shift__c> shifts1 = [SELECT Id FROM Volunteer_Shift__c WHERE Volunteer_Job__c = :job.id];
+
+        Job_Recurrence_Schedule__c jrs2 = new Job_Recurrence_Schedule__c(Volunteer_Job__c = job.Id);
+        jrs2.Days_of_Week__c = 'Monday;';
+        jrs2.Duration__c = 1;
+        jrs2.Schedule_Start_Date_Time__c = startTime.addHours(2);
+        jrs2.Weekly_Occurrence__c = '2nd';
+        jrs2.Desired_Number_of_Volunteers__c = 5;
+        insert jrs2;
+
+        List<Volunteer_Shift__c> shifts2 = [SELECT Id FROM Volunteer_Shift__c WHERE Volunteer_Job__c = :job.id];
+        System.assertEquals(shifts2.size(), shifts1.size()*2, 'Double the number of shifts should exist after second JRS is inserted.');
+
+
+        Volunteer_Recurrence_Schedule__c vrs1 = new Volunteer_Recurrence_Schedule__c(
+            Contact__c = con.Id, 
+            Volunteer_Job__c = job.Id,
+            Volunteer_Hours_Status__c = 'My Custom Status1',
+            Days_of_Week__c = 'Monday',
+            Duration__c = 1.5,
+            Number_of_Volunteers__c = 2,
+            Comments__c = 'my comments!',
+            Schedule_Start_Date_Time__c = startTime,
+            Weekly_Occurrence__c = '2nd'
+        );
+        insert vrs1;
+
+        List<Volunteer_Hours__c> vrs1hours = [
+            SELECT Id, Status__c, Comments__c, Planned_Start_Date_Time__c 
+            FROM Volunteer_Hours__c 
+            WHERE Volunteer_Recurrence_Schedule__c = :vrs1.Id 
+            ORDER BY Planned_Start_Date_Time__c
+        ];
+
+        System.assertEquals(6,vrs1hours.size(), 'First VRS inserted successfully.');
+
+        Volunteer_Recurrence_Schedule__c vrs2 = new Volunteer_Recurrence_Schedule__c(
+            Contact__c = con.Id, 
+            Volunteer_Job__c = job.Id,
+            Volunteer_Hours_Status__c = 'My Custom Status1',
+            Days_of_Week__c = 'Monday',
+            Duration__c = 1.5,
+            Number_of_Volunteers__c = 2,
+            Comments__c = 'my comments!',
+            Schedule_Start_Date_Time__c = startTime.addHours(2),
+            Weekly_Occurrence__c = '2nd'
+        );
+
+        Test.startTest();
+        insert vrs2;
+        Test.stopTest();  
+         
+        // make sure VRS1's hours untouched
+        List<Volunteer_Hours__c> vrs1hoursAfterUpdate = [
+            SELECT Id, Status__c, Comments__c, Planned_Start_Date_Time__c 
+            FROM Volunteer_Hours__c 
+            WHERE Volunteer_Recurrence_Schedule__c = :vrs1.Id 
+            ORDER BY Planned_Start_Date_Time__c
+        ];
+
+        system.assertEquals(vrs1hours.size(), vrs1hoursAfterUpdate.size());
+    }
 }


### PR DESCRIPTION
Hello friends, 

This is a small change to how Volunteer Recurrence Schedules are processed when there are duplicate VRS for the same Job and the same Contact. 

Previously, Hours records from one VRS record would be reparented to another VRS when that second one was created or processed. This change makes it so VRS processing doesn't modify Hours records belonging to another VRS not currently being processed.

I'm hitting this bug with a client so I decided to contribute the fix! Let me know if you have any questions or how I can help get this fix through.

Thanks,
Nic

# Critical Changes

# Changes

# Issues Closed
- Fixed #377

# New Metadata

# Deleted Metadata
