### PR TITLE
Limit number of Shifts displayed on VolunteersJobListingFS page

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -43,6 +43,13 @@ tasks:
                 Id guestId = [SELECT ID From User WHERE Name = 'Volunteers Site Guest User' LIMIT 1][0].id;
                 insert new PermissionSetAssignment(PermissionSetId=psetId, AssigneeId=guestId);
 
+    test_data:
+        description: Runs the generateData method from the DataCreator script with the following defaults (Pet Adoption Event, 250)
+        class_path: cumulusci.tasks.apex.anon.AnonymousApexTask
+        options:
+            path: scripts/DataCreator.cls
+            apex: generateData(defaultCampaignName, defaultNumberOfShifts);
+
 flows:
     ci_feature:
         description: Deploys the unmanaged package metadata and all dependencies to the target org and runs tests

--- a/scripts/DataCreator.cls
+++ b/scripts/DataCreator.cls
@@ -1,0 +1,32 @@
+// Create a Job with Shifts
+String uniqueName = String.valueOf(System.now());
+String defaultCampaignName = 'Pet Adoption Event';
+Integer defaultNumberOfShifts = 250;
+
+public static void generateData(String campaignName, Integer numberOfShifts) {
+    Campaign campaignRecord = new Campaign(
+    Name = campaignName + ' ' + uniqueName,
+    IsActive = true);
+    insert campaignRecord;
+
+    Volunteer_Job__c job = new Volunteer_Job__c(
+        Name =  campaignName + ' Job ' + uniqueName,
+        Campaign__c = campaignRecord.Id,
+        Display_on_Website__c = true
+    );
+    insert job;
+
+    List<Volunteer_Shift__c> shifts = new List<Volunteer_Shift__c>();
+    for (Integer counter = 0; counter < (numberOfShifts / 10); counter++) {
+        for (Integer additionalMonths = 0; additionalMonths < 10; additionalMonths++) {
+            shifts.add(new Volunteer_Shift__c(
+                Volunteer_Job__c = job.Id,
+                Desired_Number_of_Volunteers__c = 10,
+                Duration__c = 2,
+                Start_Date_Time__c = System.now().addMonths(additionalMonths)
+            ));
+        }
+    }
+    insert shifts;
+}
+

--- a/src/classes/VOL_CTRL_VolunteersJobListingFS.cls
+++ b/src/classes/VOL_CTRL_VolunteersJobListingFS.cls
@@ -29,6 +29,15 @@
 */
 
 global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
+    /**
+     * Hard coding the subquery limit to 200 to prevent an error being displayed when
+     * attempting to access the list of child records when more than 200 are present
+     * https://success.salesforce.com/issues_view?id=a1p300000008YGjAAM&title=invalid-query-locator-error-occurs-when-iterating-child-objects-in-parent-child-relationship-query-result
+     * NOTE: In a test environment we are not hitting this error until we have 250 child records
+     * but our customers are running into this at 200 likely due to more fields being populated and returned
+     */
+    @TestVisible
+    private static Integer SUBQUERY_LIMIT = 200;
 
     // page parameters that can get passed into the page to control its behavior.
     global ID campaignIdFilter { get; set; }
@@ -279,7 +288,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
                         (Select Id, Start_Date_Time__c, Duration__c, Number_of_Volunteers_Still_Needed__c, Total_Volunteers__c,
                             Description__c, System_Note__c From Volunteer_Job_Slots__r 
                             where Start_Date_Time__c >= :dtNow and Start_Date_Time__c < :dtLast
-                            order by Start_Date_Time__c LIMIT 200) 
+                            order by Start_Date_Time__c LIMIT :SUBQUERY_LIMIT) 
                         from Volunteer_Job__c where Id = :jobIdFilter  
                         order by First_Shift__c, Campaign__r.StartDate, Campaign__r.Name, Name];
                 } else if (campaignIdFilter != null) {
@@ -293,7 +302,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
                         (Select Id, Start_Date_Time__c, Duration__c, Number_of_Volunteers_Still_Needed__c, Total_Volunteers__c,
                             Description__c, System_Note__c From Volunteer_Job_Slots__r 
                             where Start_Date_Time__c >= :dtNow and Start_Date_Time__c < :dtLast
-                            order by Start_Date_Time__c LIMIT 200) 
+                            order by Start_Date_Time__c LIMIT :SUBQUERY_LIMIT) 
                         from Volunteer_Job__c where Campaign__c IN :listCampaignIds and Display_on_Website__c = true 
                         order by First_Shift__c, Campaign__r.StartDate, Campaign__r.Name, Name];
                 } else {

--- a/src/classes/VOL_CTRL_VolunteersJobListingFS.cls
+++ b/src/classes/VOL_CTRL_VolunteersJobListingFS.cls
@@ -37,7 +37,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
      * but our customers are running into this at 200 likely due to more fields being populated and returned
      */
     @TestVisible
-    private static Integer SUBQUERY_LIMIT = 200;
+    private static final Integer SUBQUERY_LIMIT = 200;
 
     // page parameters that can get passed into the page to control its behavior.
     global ID campaignIdFilter { get; set; }

--- a/src/classes/VOL_CTRL_VolunteersJobListingFS.cls
+++ b/src/classes/VOL_CTRL_VolunteersJobListingFS.cls
@@ -279,7 +279,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
                         (Select Id, Start_Date_Time__c, Duration__c, Number_of_Volunteers_Still_Needed__c, Total_Volunteers__c,
                             Description__c, System_Note__c From Volunteer_Job_Slots__r 
                             where Start_Date_Time__c >= :dtNow and Start_Date_Time__c < :dtLast
-                            order by Start_Date_Time__c) 
+                            order by Start_Date_Time__c LIMIT 200) 
                         from Volunteer_Job__c where Id = :jobIdFilter  
                         order by First_Shift__c, Campaign__r.StartDate, Campaign__r.Name, Name];
                 } else if (campaignIdFilter != null) {
@@ -293,7 +293,7 @@ global virtual with sharing class VOL_CTRL_VolunteersJobListingFS {
                         (Select Id, Start_Date_Time__c, Duration__c, Number_of_Volunteers_Still_Needed__c, Total_Volunteers__c,
                             Description__c, System_Note__c From Volunteer_Job_Slots__r 
                             where Start_Date_Time__c >= :dtNow and Start_Date_Time__c < :dtLast
-                            order by Start_Date_Time__c) 
+                            order by Start_Date_Time__c LIMIT 200) 
                         from Volunteer_Job__c where Campaign__c IN :listCampaignIds and Display_on_Website__c = true 
                         order by First_Shift__c, Campaign__r.StartDate, Campaign__r.Name, Name];
                 } else {

--- a/src/classes/VOL_CTRL_VolunteersJobListingFS_TEST.cls
+++ b/src/classes/VOL_CTRL_VolunteersJobListingFS_TEST.cls
@@ -40,7 +40,9 @@ private with sharing class VOL_CTRL_VolunteersJobListingFS_TEST {
         Id shiftId = [SELECT Id FROM Volunteer_Shift__c Where Volunteer_Job__c = :jobId LIMIT 1].Id;
         setupPage(new Map<String, String>{'jobId' => jobId, 'volunteerShiftId' => shiftId, 'nMonthsToShow' => '0'});
 
-        System.assertEquals(shiftId, jobListingCtrl.shiftIdFilter);
+        System.assertEquals(jobId, jobListingCtrl.jobIdFilter, 'Expecting the job Id filter on the controller to match the parameter passed in.');
+        System.assertEquals(shiftId, jobListingCtrl.shiftIdFilter, 'Expecting the shift Id filter on the controller to match the parameter passed in.');
+        System.assertEquals(0, jobListingCtrl.nMonthsToShow, 'Expecting the nMonthsToShow on the controller to match the parameter passed in.');
         System.assertEquals(1, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
     }
 
@@ -50,22 +52,22 @@ private with sharing class VOL_CTRL_VolunteersJobListingFS_TEST {
         Id jobId = [SELECT Id FROM Volunteer_Job__c LIMIT 1].Id;
         setupPage(new Map<String, String>{'jobId' => jobId});
 
-        System.assertEquals(jobId, jobListingCtrl.jobIdFilter);
+        System.assertEquals(jobId, jobListingCtrl.jobIdFilter, 'Expecting the job Id filter on the controller to match the parameter passed in.');
         System.assertEquals(10, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
     }
 
     @IsTest
-    private static void shouldReturnAllShiftsWhenCampaingIdIsProvidedAndLessThanLimit() {
+    private static void shouldReturnAllShiftsWhenCampaignIdIsProvidedAndLessThanLimit() {
         generateData(10);
         Id campaignId = [SELECT Id FROM Campaign LIMIT 1].Id;
         setupPage(new Map<String, String>{'campaignId' => campaignId});
 
-        System.assertEquals(campaignId, jobListingCtrl.campaignIdFilter);
+        System.assertEquals(campaignId, jobListingCtrl.campaignIdFilter, 'Expecting the campaign Id filter on the controller to match the parameter passed in.');
         System.assertEquals(10, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
     }
 
     @IsTest
-    private static void shouldRetrunLimitedShiftsWhenIdFiltersAreNotProvided() {
+    private static void shouldReturnnLimitedShiftsWhenIdFiltersAreNotProvided() {
         generateData(101);
         setupPage(new Map<String, String>());
 
@@ -73,22 +75,22 @@ private with sharing class VOL_CTRL_VolunteersJobListingFS_TEST {
     }
 
     @IsTest
-    private static void shouldRetrunLimitedShiftsWhenJobIdIsProvided() {
+    private static void shouldReturnnLimitedShiftsWhenJobIdIsProvided() {
         generateData(251);
         Id jobId = [SELECT Id FROM Volunteer_Job__c LIMIT 1].Id;
         setupPage(new Map<String, String>{'jobId' => jobId});
 
-        System.assertEquals(jobId, jobListingCtrl.jobIdFilter);
+        System.assertEquals(jobId, jobListingCtrl.jobIdFilter, 'Expecting the job Id filter on the controller to match the parameter passed in.');
         System.assertEquals(200, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
     }
 
     @IsTest
-    private static void shouldRetrunLimitedShiftsWhenCampaignIdIsProvided() {
+    private static void shouldReturnnLimitedShiftsWhenCampaignIdIsProvided() {
         generateData(251);
         Id campaignId = [SELECT Id FROM Campaign LIMIT 1].Id;
         setupPage(new Map<String, String>{'campaignId' => campaignId});
 
-        System.assertEquals(campaignId, jobListingCtrl.campaignIdFilter);
+        System.assertEquals(campaignId, jobListingCtrl.campaignIdFilter, 'Expecting the campaign Id filter on the controller to match the parameter passed in.');
         System.assertEquals(200, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
     }
 

--- a/src/classes/VOL_CTRL_VolunteersJobListingFS_TEST.cls
+++ b/src/classes/VOL_CTRL_VolunteersJobListingFS_TEST.cls
@@ -30,8 +30,109 @@
 
 @isTest
 private with sharing class VOL_CTRL_VolunteersJobListingFS_TEST {
+    private static VOL_CTRL_VolunteersJobListingFS jobListingCtrl;
 
     //==================== TEST METHOD(s) ======================================
+    @IsTest
+    private static void shouldReturnOneShiftWhenJobIdAndShiftIdAreProvidedWithZeroMonths() {
+        generateData(10);
+        Id jobId = [SELECT Id FROM Volunteer_Job__c LIMIT 1].Id;
+        Id shiftId = [SELECT Id FROM Volunteer_Shift__c Where Volunteer_Job__c = :jobId LIMIT 1].Id;
+        setupPage(new Map<String, String>{'jobId' => jobId, 'volunteerShiftId' => shiftId, 'nMonthsToShow' => '0'});
+
+        System.assertEquals(shiftId, jobListingCtrl.shiftIdFilter);
+        System.assertEquals(1, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
+    }
+
+    @IsTest
+    private static void shouldReturnAllShiftsWhenJobIdIsProvidedAndLessThanLimit() {
+        generateData(10);
+        Id jobId = [SELECT Id FROM Volunteer_Job__c LIMIT 1].Id;
+        setupPage(new Map<String, String>{'jobId' => jobId});
+
+        System.assertEquals(jobId, jobListingCtrl.jobIdFilter);
+        System.assertEquals(10, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
+    }
+
+    @IsTest
+    private static void shouldReturnAllShiftsWhenCampaingIdIsProvidedAndLessThanLimit() {
+        generateData(10);
+        Id campaignId = [SELECT Id FROM Campaign LIMIT 1].Id;
+        setupPage(new Map<String, String>{'campaignId' => campaignId});
+
+        System.assertEquals(campaignId, jobListingCtrl.campaignIdFilter);
+        System.assertEquals(10, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
+    }
+
+    @IsTest
+    private static void shouldRetrunLimitedShiftsWhenIdFiltersAreNotProvided() {
+        generateData(101);
+        setupPage(new Map<String, String>());
+
+        System.assertEquals(100, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
+    }
+
+    @IsTest
+    private static void shouldRetrunLimitedShiftsWhenJobIdIsProvided() {
+        generateData(251);
+        Id jobId = [SELECT Id FROM Volunteer_Job__c LIMIT 1].Id;
+        setupPage(new Map<String, String>{'jobId' => jobId});
+
+        System.assertEquals(jobId, jobListingCtrl.jobIdFilter);
+        System.assertEquals(200, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
+    }
+
+    @IsTest
+    private static void shouldRetrunLimitedShiftsWhenCampaignIdIsProvided() {
+        generateData(251);
+        Id campaignId = [SELECT Id FROM Campaign LIMIT 1].Id;
+        setupPage(new Map<String, String>{'campaignId' => campaignId});
+
+        System.assertEquals(campaignId, jobListingCtrl.campaignIdFilter);
+        System.assertEquals(200, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
+    }
+
+    private static void setupPage(Map<String, String> params) {
+        PageReference pageRef = Page.VolunteersJobListingFS;
+
+        for (String param : params.keySet()) {
+            pageRef.getParameters().put(param, params.get(param));
+        }
+
+        Test.setCurrentPage(pageRef);
+        jobListingCtrl = new VOL_CTRL_VolunteersJobListingFS();
+    }
+
+    private static void generateData(Integer numberOfShifts) {
+        Volunteers_Settings__c settings = new Volunteers_Settings__c();
+        VOL_SharedCode.getVolunteersSettingsForTests(settings);
+
+        String uniqueName = String.valueOf(System.now());
+        String campaignName = 'Pet Adoption Event';
+
+        Campaign campaignRecord = new Campaign(
+        Name = campaignName + ' ' + uniqueName,
+        IsActive = true);
+        insert campaignRecord;
+
+        Volunteer_Job__c job = new Volunteer_Job__c(
+            Name =  campaignName + ' Job ' + uniqueName,
+            Campaign__c = campaignRecord.Id,
+            Display_on_Website__c = true
+        );
+        insert job;
+
+        List<Volunteer_Shift__c> shifts = new List<Volunteer_Shift__c>();
+        for (Integer counter = 0; counter < numberOfShifts; counter++) {
+            shifts.add(new Volunteer_Shift__c(
+                Volunteer_Job__c = job.Id,
+                Desired_Number_of_Volunteers__c = 10,
+                Duration__c = 2,
+                Start_Date_Time__c = System.today().addDays(1)
+            ));
+        }
+        insert shifts;
+    }
 
 
     /*******************************************************************************************************

--- a/src/classes/VOL_CTRL_VolunteersJobListingFS_TEST.cls
+++ b/src/classes/VOL_CTRL_VolunteersJobListingFS_TEST.cls
@@ -31,7 +31,7 @@
 @isTest
 private with sharing class VOL_CTRL_VolunteersJobListingFS_TEST {
     private static VOL_CTRL_VolunteersJobListingFS jobListingCtrl;
-    private static final Integer queryLimit = VOL_CTRL_VolunteersJobListingFS.SUBQUERY_LIMIT;
+    private static final Integer QUERY_LIMIT = VOL_CTRL_VolunteersJobListingFS.SUBQUERY_LIMIT;
     private static final Integer SUBQUERY_ERROR_THRESHOLD = 251; // causes query exception with test data at this number
 
     //==================== TEST METHOD(s) ======================================
@@ -83,7 +83,7 @@ private with sharing class VOL_CTRL_VolunteersJobListingFS_TEST {
         setupPage(new Map<String, String>{'jobId' => jobId});
 
         System.assertEquals(jobId, jobListingCtrl.jobIdFilter, 'Expecting the job Id filter on the controller to match the parameter passed in.');
-        System.assertEquals(queryLimit, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
+        System.assertEquals(QUERY_LIMIT, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
     }
 
     @IsTest
@@ -93,7 +93,7 @@ private with sharing class VOL_CTRL_VolunteersJobListingFS_TEST {
         setupPage(new Map<String, String>{'campaignId' => campaignId});
 
         System.assertEquals(campaignId, jobListingCtrl.campaignIdFilter, 'Expecting the campaign Id filter on the controller to match the parameter passed in.');
-        System.assertEquals(queryLimit, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
+        System.assertEquals(QUERY_LIMIT, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
     }
 
     private static void setupPage(Map<String, String> params) {

--- a/src/classes/VOL_CTRL_VolunteersJobListingFS_TEST.cls
+++ b/src/classes/VOL_CTRL_VolunteersJobListingFS_TEST.cls
@@ -69,7 +69,7 @@ private with sharing class VOL_CTRL_VolunteersJobListingFS_TEST {
     }
 
     @IsTest
-    private static void shouldReturnnLimitedShiftsWhenIdFiltersAreNotProvided() {
+    private static void shouldReturnLimitedShiftsWhenIdFiltersAreNotProvided() {
         generateData(101);
         setupPage(new Map<String, String>());
 
@@ -77,7 +77,7 @@ private with sharing class VOL_CTRL_VolunteersJobListingFS_TEST {
     }
 
     @IsTest
-    private static void shouldReturnnLimitedShiftsWhenJobIdIsProvided() {
+    private static void shouldReturnLimitedShiftsWhenJobIdIsProvided() {
         generateData(SUBQUERY_ERROR_THRESHOLD);
         Id jobId = [SELECT Id FROM Volunteer_Job__c LIMIT 1].Id;
         setupPage(new Map<String, String>{'jobId' => jobId});
@@ -87,7 +87,7 @@ private with sharing class VOL_CTRL_VolunteersJobListingFS_TEST {
     }
 
     @IsTest
-    private static void shouldReturnnLimitedShiftsWhenCampaignIdIsProvided() {
+    private static void shouldReturnLimitedShiftsWhenCampaignIdIsProvided() {
         generateData(SUBQUERY_ERROR_THRESHOLD);
         Id campaignId = [SELECT Id FROM Campaign LIMIT 1].Id;
         setupPage(new Map<String, String>{'campaignId' => campaignId});

--- a/src/classes/VOL_CTRL_VolunteersJobListingFS_TEST.cls
+++ b/src/classes/VOL_CTRL_VolunteersJobListingFS_TEST.cls
@@ -31,6 +31,8 @@
 @isTest
 private with sharing class VOL_CTRL_VolunteersJobListingFS_TEST {
     private static VOL_CTRL_VolunteersJobListingFS jobListingCtrl;
+    private static final Integer queryLimit = VOL_CTRL_VolunteersJobListingFS.SUBQUERY_LIMIT;
+    private static final Integer SUBQUERY_ERROR_THRESHOLD = 251; // causes query exception with test data at this number
 
     //==================== TEST METHOD(s) ======================================
     @IsTest
@@ -76,22 +78,22 @@ private with sharing class VOL_CTRL_VolunteersJobListingFS_TEST {
 
     @IsTest
     private static void shouldReturnnLimitedShiftsWhenJobIdIsProvided() {
-        generateData(251);
+        generateData(SUBQUERY_ERROR_THRESHOLD);
         Id jobId = [SELECT Id FROM Volunteer_Job__c LIMIT 1].Id;
         setupPage(new Map<String, String>{'jobId' => jobId});
 
         System.assertEquals(jobId, jobListingCtrl.jobIdFilter, 'Expecting the job Id filter on the controller to match the parameter passed in.');
-        System.assertEquals(200, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
+        System.assertEquals(queryLimit, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
     }
 
     @IsTest
     private static void shouldReturnnLimitedShiftsWhenCampaignIdIsProvided() {
-        generateData(251);
+        generateData(SUBQUERY_ERROR_THRESHOLD);
         Id campaignId = [SELECT Id FROM Campaign LIMIT 1].Id;
         setupPage(new Map<String, String>{'campaignId' => campaignId});
 
         System.assertEquals(campaignId, jobListingCtrl.campaignIdFilter, 'Expecting the campaign Id filter on the controller to match the parameter passed in.');
-        System.assertEquals(200, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
+        System.assertEquals(queryLimit, jobListingCtrl.listVolunteerJobs[0].Volunteer_Job_Slots__r.size(), 'The number of shifts returned was not as expected.');
     }
 
     private static void setupPage(Map<String, String> params) {


### PR DESCRIPTION
# Critical Changes

# Changes
When displaying a volunteer job with more than 200 related shifts is shown on the VolunteersJobListingFS page only the first 200 shifts will be displayed. To display more than 200 shifts you may need to split the shifts between multiple volunteer jobs.

# Issues Closed
- Fixes #359 

# New Metadata

# Deleted Metadata
