### PR TITLE
W-7173930 - Validate External Signup URL

### DIFF
--- a/src/objects/Volunteer_Job__c.object
+++ b/src/objects/Volunteer_Job__c.object
@@ -762,11 +762,11 @@
         <protected>false</protected>
         <url>/apex/{!$Setup.PackageSettings__c.NamespacePrefix__c}SendBulkEmail?jobId={!Volunteer_Job__c.Id}</url>
     </webLinks>
-    <!-- <validationRules>
+    <validationRules>
         <fullName>ValidateExternalSignupUrl</fullName>
         <active>true</active>
         <errorConditionFormula>NOT(REGEX(External_Signup_Url__c,"^((http|https)://)??(www[.])??([a-zA-Z0-9]|-)+?([.][a-zA-Z0-9(-|/|=|?)??]+?)+?$"))</errorConditionFormula>
         <errorDisplayField>External_Signup_Url__c</errorDisplayField>
         <errorMessage>Please enter a valid URL.</errorMessage>
-    </validationRules> -->
+    </validationRules>
 </CustomObject>

--- a/src/objects/Volunteer_Job__c.object
+++ b/src/objects/Volunteer_Job__c.object
@@ -765,7 +765,7 @@
     <validationRules>
         <fullName>ValidateExternalSignupUrl</fullName>
         <active>true</active>
-        <errorConditionFormula>NOT(REGEX(External_Signup_Url__c,"^((http|https)://)??(www[.])??([a-zA-Z0-9]|-)+?([.][a-zA-Z0-9(-|/|=|?)??]+?)+?$"))</errorConditionFormula>
+        <errorConditionFormula>NOT(OR(ISBLANK(External_Signup_Url__c),REGEX(External_Signup_Url__c,"^((http|https)://)??(www[.])??([a-zA-Z0-9]|-)+?([.][a-zA-Z0-9(-|/|=|?)??]+?)+?$")))</errorConditionFormula>
         <errorDisplayField>External_Signup_Url__c</errorDisplayField>
         <errorMessage>Please enter a valid URL.</errorMessage>
     </validationRules>

--- a/src/objects/Volunteer_Job__c.object
+++ b/src/objects/Volunteer_Job__c.object
@@ -762,4 +762,11 @@
         <protected>false</protected>
         <url>/apex/{!$Setup.PackageSettings__c.NamespacePrefix__c}SendBulkEmail?jobId={!Volunteer_Job__c.Id}</url>
     </webLinks>
+    <validationRules>
+        <fullName>ValidateExternalSignupUrl</fullName>
+        <active>true</active>
+        <errorConditionFormula>IF(REGEX(External_Signup_Url__c,&quot;^((http|https)://)??(www[.])??([a-zA-Z0-9]|-)+?([.][a-zA-Z0-9(-|/|=|?)??]+?)+?$&quot;),false,true)</errorConditionFormula>
+        <errorDisplayField>External_Signup_Url__c</errorDisplayField>
+        <errorMessage>Please enter a valid URL.</errorMessage>
+    </validationRules>    
 </CustomObject>

--- a/src/objects/Volunteer_Job__c.object
+++ b/src/objects/Volunteer_Job__c.object
@@ -765,7 +765,8 @@
     <validationRules>
         <fullName>ValidateExternalSignupUrl</fullName>
         <active>true</active>
-        <errorConditionFormula>NOT(OR(ISBLANK(External_Signup_Url__c),REGEX(External_Signup_Url__c,"^((http|https)://)??(www[.])??([a-zA-Z0-9]|-)+?([.][a-zA-Z0-9(-|/|=|?)??]+?)+?$")))</errorConditionFormula>
+        <description>Validates that the External Signup URL field begins with an expected protocol.</description>
+        <errorConditionFormula>NOT(OR(ISBLANK(External_Signup_Url__c), REGEX(External_Signup_Url__c,"^(http|https|mailto).*")))</errorConditionFormula>
         <errorDisplayField>External_Signup_Url__c</errorDisplayField>
         <errorMessage>Please enter a valid URL.</errorMessage>
     </validationRules>

--- a/src/objects/Volunteer_Job__c.object
+++ b/src/objects/Volunteer_Job__c.object
@@ -765,7 +765,7 @@
     <validationRules>
         <fullName>ValidateExternalSignupUrl</fullName>
         <active>true</active>
-        <errorConditionFormula>NOT(REGEX(External_Signup_Url__c,"^((http|https)://)??(www[.])??([a-zA-Z0-9]|-)+?([.][a-zA-Z0-9(-|/|=|?)??]+?)+?$"))</errorConditionFormula>
+        <errorConditionFormula>NOT(REGEX(External_Signup_Url__c,"^((http|https):\/\/)??(www[.])??([a-zA-Z0-9]|-)+?([.][a-zA-Z0-9(-|/|=|?)??]+?)+?$"))</errorConditionFormula>
         <errorDisplayField>External_Signup_Url__c</errorDisplayField>
         <errorMessage>Please enter a valid URL.</errorMessage>
     </validationRules>    

--- a/src/objects/Volunteer_Job__c.object
+++ b/src/objects/Volunteer_Job__c.object
@@ -765,7 +765,7 @@
     <validationRules>
         <fullName>ValidateExternalSignupUrl</fullName>
         <active>true</active>
-        <errorConditionFormula>NOT(REGEX(External_Signup_Url__c,"^((http|https):\/\/)??(www[.])??([a-zA-Z0-9]|-)+?([.][a-zA-Z0-9(-|/|=|?)??]+?)+?$"))</errorConditionFormula>
+        <errorConditionFormula>NOT(REGEX(External_Signup_Url__c,"^((http|https)://)??(www[.])??([a-zA-Z0-9]|-)+?([.][a-zA-Z0-9(-|/|=|?)??]+?)+?$"))</errorConditionFormula>
         <errorDisplayField>External_Signup_Url__c</errorDisplayField>
         <errorMessage>Please enter a valid URL.</errorMessage>
     </validationRules>    

--- a/src/objects/Volunteer_Job__c.object
+++ b/src/objects/Volunteer_Job__c.object
@@ -765,7 +765,7 @@
     <validationRules>
         <fullName>ValidateExternalSignupUrl</fullName>
         <active>true</active>
-        <description>Validates that the External Signup URL field begins with an expected protocol.</description>
+        <description>Validates that the External Signup URL field begins with an expected URI Scheme.</description>
         <errorConditionFormula>NOT(OR(ISBLANK(External_Signup_Url__c), REGEX(External_Signup_Url__c,"^(http|https|mailto).*")))</errorConditionFormula>
         <errorDisplayField>External_Signup_Url__c</errorDisplayField>
         <errorMessage>Please enter a valid URL.</errorMessage>

--- a/src/objects/Volunteer_Job__c.object
+++ b/src/objects/Volunteer_Job__c.object
@@ -762,11 +762,11 @@
         <protected>false</protected>
         <url>/apex/{!$Setup.PackageSettings__c.NamespacePrefix__c}SendBulkEmail?jobId={!Volunteer_Job__c.Id}</url>
     </webLinks>
-    <validationRules>
+    <!-- <validationRules>
         <fullName>ValidateExternalSignupUrl</fullName>
         <active>true</active>
         <errorConditionFormula>NOT(REGEX(External_Signup_Url__c,"^((http|https)://)??(www[.])??([a-zA-Z0-9]|-)+?([.][a-zA-Z0-9(-|/|=|?)??]+?)+?$"))</errorConditionFormula>
         <errorDisplayField>External_Signup_Url__c</errorDisplayField>
         <errorMessage>Please enter a valid URL.</errorMessage>
-    </validationRules>    
+    </validationRules> -->
 </CustomObject>

--- a/src/objects/Volunteer_Job__c.object
+++ b/src/objects/Volunteer_Job__c.object
@@ -765,7 +765,7 @@
     <validationRules>
         <fullName>ValidateExternalSignupUrl</fullName>
         <active>true</active>
-        <errorConditionFormula>IF(REGEX(External_Signup_Url__c,&quot;^((http|https)://)??(www[.])??([a-zA-Z0-9]|-)+?([.][a-zA-Z0-9(-|/|=|?)??]+?)+?$&quot;),false,true)</errorConditionFormula>
+        <errorConditionFormula>NOT(REGEX(External_Signup_Url__c,"^((http|https)://)??(www[.])??([a-zA-Z0-9]|-)+?([.][a-zA-Z0-9(-|/|=|?)??]+?)+?$"))</errorConditionFormula>
         <errorDisplayField>External_Signup_Url__c</errorDisplayField>
         <errorMessage>Please enter a valid URL.</errorMessage>
     </validationRules>    

--- a/src/objects/Volunteer_Job__c.object
+++ b/src/objects/Volunteer_Job__c.object
@@ -768,6 +768,6 @@
         <description>Validates that the External Signup URL field begins with an expected URI Scheme.</description>
         <errorConditionFormula>NOT(OR(ISBLANK(External_Signup_Url__c), REGEX(External_Signup_Url__c,"^(http|https|mailto).*")))</errorConditionFormula>
         <errorDisplayField>External_Signup_Url__c</errorDisplayField>
-        <errorMessage>Please enter a valid URL.</errorMessage>
+        <errorMessage>The External Signup Url value must begin with http, https, or mailto.</errorMessage>
     </validationRules>
 </CustomObject>

--- a/src/package.xml
+++ b/src/package.xml
@@ -689,6 +689,7 @@
         <members>Job_Recurrence_Schedule__c.JRS_Weekly_Occurrence_Required</members>
         <members>Volunteer_Hours__c.HoursRequiredOnCompletion</members>
         <members>Volunteer_Hours__c.StatusMustBeSet</members>
+        <members>Volunteer_Job__c.ValidateExternalSignupUrl</members>
         <members>Volunteer_Recurrence_Schedule__c.VRS_Days_of_Week_Required</members>
         <members>Volunteer_Recurrence_Schedule__c.VRS_Weekly_Occurrence_Required</members>
         <name>ValidationRule</name>


### PR DESCRIPTION
Add validation rule to External Signup URL field on Volunteer Job object. 

# Critical Changes

We introduced a new validation rule, ValidateExternalSignupUrl, on the Volunteer Job object. This rule ensures that the External Signup URL field doesn’t contain malicious code by validating that the field value begins with http, https, or mailto. 

If this field has an invalid value, it will impact your ability to update the Volunteer Job record, and affect your volunteers' ability to report hours or update data on your Volunteer site. Therefore, we recommend that you check your External Signup URL field values on the Volunteer Job object and ensure that they comply with the new requirement. To get a list of your External Signup URL field values:

1. Create a custom report using the Volunteer Jobs with Shifts & Hours report type. 
2. Add External Signup URL as a column.
3. Add a filter for External Signup URL, with the Operator set to *Does not contain*, and the value set to http,https,mailto.

If you run into major issues, you can deactivate the new validation rule (https://help.salesforce.com/articleView?id=fields_activating_field_validation_rules.htm&type=5) and create your own. Please keep in mind that if you disable the validation rule, you could be opening up your org to security issues.


# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
