### PR TITLE
Make config_qa work managed

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -229,18 +229,13 @@ flows:
                 task: deploy_delete_config
             4:
                 task: deploy_dev_config
-                options:
-                    unmanaged: True
             5:
                 task: deploy_qa_config
-                options:
-                    unmanaged: True
             6:
                 task: deploy_tab_config
-                options:
-                    unmanaged: True
             7:
                 task: deploy_package_settings
+                when: "'GW_Volunteers' not in org_config.installed_packages"
             8:
                 task: assign_pset
                 ignore_failure: True


### PR DESCRIPTION
This PR alters config_qa to work in a managed context to support the qa_org_2gp flow.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata
