### PR TITLE
PersonalSiteContactInfo: Allow Comments to be exposed directly

### DIFF
--- a/src/classes/VOL_CTRL_PersonalSiteContactInfo.cls
+++ b/src/classes/VOL_CTRL_PersonalSiteContactInfo.cls
@@ -238,7 +238,6 @@ global with sharing class VOL_CTRL_PersonalSiteContactInfo {
     // for the shifts start time - end date & time, using the appropriate
     // time zone that might be specified on the Job, Campaign, or Site Guest User.
     // Note that it stores the formatted Time in the Hours' System_Note__c field (in memory only).
-    // Note that it stores the formatted Date in the Hours' Comment field (in memory only).
     private void dateTimeFixup(list<Volunteer_Hours__c> listHours) {
         // get default time zone for site guest user
         User u = [Select TimeZoneSidKey From User where id =: Userinfo.getUserId()];
@@ -256,7 +255,6 @@ global with sharing class VOL_CTRL_PersonalSiteContactInfo {
             if (dtStart == null) {
                 // if we don't have a start time, then format by GMT, to avoid timezones moving the date!
                 dtStart = hr.Start_Date__c;
-                hr.Comments__c = dtStart.formatGmt(strDateFormat);
             } else {
                 double duration = hr.Hours_Worked__c == null ? hr.Volunteer_Shift__r.Duration__c : hr.Hours_Worked__c;
                 DateTime dtEnd = dtStart.addMinutes(integer.valueOf(duration * 60));
@@ -267,10 +265,7 @@ global with sharing class VOL_CTRL_PersonalSiteContactInfo {
                     hr.System_Note__c =  dtStart.format(strFormatEndTime, strTimeZone) + ' - ' + dtEnd.format(strFormatEndTime, strTimeZone);   
                 } else {
                     hr.System_Note__c =  dtStart.format(strFormatEndTime, strTimeZone) + ' - ' + dtEnd.format(strFormat, strTimeZone);                      
-                } 
-                
-                // also save user formated Start Date in Comments field
-                hr.Comments__c = dtStart.format(strDateFormat, strTimeZone);
+                }
             }           
         }
     }


### PR DESCRIPTION
Stop storing the formatted start date in the Comments field, so that it can be successfully exposed in the Volunteer UI.

# Critical Changes

# Changes

# Issues Closed
Fixes #466 

# New Metadata

# Deleted Metadata
